### PR TITLE
GAN-262: Fix `gSQLExporter` for IBOS1 and IBOS2

### DIFF
--- a/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
+++ b/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
@@ -117,6 +117,8 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
 
                 aktuelleSektion.Items.Add(new gSQLItem()); // Leerzeile
                 aktuelleSektion.Items.Add(new gSQLItem("Position_PositionsNummer", pos.PositionsNummer));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_LaufendeNummer", pos.LaufendeNummer.ToString()));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_Nummer", pos.PositionsNummer));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_PositionsGuid", pos.BelegPositionGuid.ToString()));
 
                 if (pos.Variante != null)
@@ -134,12 +136,12 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
                     aktuelleSektion.Items.Add(new gSQLItem("SystemTyp", "Sonderposition"));
                 }
 
-                aktuelleSektion.Items.Add(new gSQLItem("Position_LaufendeNummer", pos.LaufendeNummer.ToString()));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_Nummer", pos.PositionsNummer));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Menge", pos.Menge.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_MengenEinheit", pos.MengenEinheit));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Besonderheiten", pos.Besonderheiten));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Einbauort", pos.Einbauort));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_IstAktiv", pos.IstAktiv.ToString()));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_IstAlternativPosition", pos.IstAlternativPosition.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_PositionsKommission", pos.PositionsKommission));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Text", pos.Text?.Replace("\r", "||").Replace("\n", "")));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_AngebotsText", pos.AngebotsText?.Replace("\r", "||").Replace("\n", "")));

--- a/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
+++ b/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
@@ -49,7 +49,7 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
             //aktuelleSektion.Items.Add(new gSQLItem("Kundennummer", vorgang.Kontakt?.KundenNummer));
             //aktuelleSektion.Items.Add(new gSQLItem("HaendlerMandantGuid", vorgang.Kontakt.KontaktMandantGuid.ToString()));
             aktuelleSektion.Items.Add(new gSQLItem("VorgangGuid", vorgang.VorgangGuid.ToString()));
-            //aktuelleSektion.Items.Add(new gSQLItem("OriginalVorgangGuid", vorgang.OriginalVorgangGuid.ToString()));
+            aktuelleSektion.Items.Add(new gSQLItem("OriginalVorgangGuid", vorgang.OriginalVorgangGuid.ToString()));
             //aktuelleSektion.Items.Add(new gSQLItem("OriginalVorgangsNummer", vorgang.OriginalVorgangsNummer?.ToString() ?? String.Empty));
             aktuelleSektion.Items.Add(new gSQLItem("Beleg_IstTestBeleg", vorgang.IstTestbeleg.ToString()));
             result.Sektionen.Add(aktuelleSektion);
@@ -139,6 +139,9 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Menge", pos.Menge.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_MengenEinheit", pos.MengenEinheit));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Besonderheiten", SanitizeString(pos.Besonderheiten)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_ProduktionZusatzInfo", SanitizeString(pos.ProduktionZusatzInfo)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_ProduktionZusatzInfoPrintOnReport", SanitizeString(pos.ProduktionZusatzInfoPrintOnReport.ToString())));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_ProduktionZusatzInfoPrintZusatzEtikett", SanitizeString(pos.ProduktionZusatzInfoPrintZusatzEtikett.ToString())));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Einbauort", SanitizeString(pos.Einbauort)));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_IstAktiv", pos.IstAktiv.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_IstAlternativPosition", pos.IstAlternativPosition.ToString()));

--- a/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
+++ b/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLExporter.cs
@@ -138,15 +138,15 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
 
                 aktuelleSektion.Items.Add(new gSQLItem("Position_Menge", pos.Menge.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_MengenEinheit", pos.MengenEinheit));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_Besonderheiten", pos.Besonderheiten));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_Einbauort", pos.Einbauort));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_Besonderheiten", SanitizeString(pos.Besonderheiten)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_Einbauort", SanitizeString(pos.Einbauort)));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_IstAktiv", pos.IstAktiv.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_IstAlternativPosition", pos.IstAlternativPosition.ToString()));
                 aktuelleSektion.Items.Add(new gSQLItem("Position_PositionsKommission", pos.PositionsKommission));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_Text", pos.Text?.Replace("\r", "||").Replace("\n", "")));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_AngebotsText", pos.AngebotsText?.Replace("\r", "||").Replace("\n", "")));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_SonderwunschText", pos.SonderwunschText?.Replace("\r", "||").Replace("\n", "")));
-                aktuelleSektion.Items.Add(new gSQLItem("Position_SonderwunschAngebotsText", pos.SonderwunschAngebotsText?.Replace("\r", "||").Replace("\n", "")));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_Text", SanitizeString(pos.Text)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_AngebotsText", SanitizeString(pos.AngebotsText)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_SonderwunschText", SanitizeString(pos.SonderwunschText)));
+                aktuelleSektion.Items.Add(new gSQLItem("Position_SonderwunschAngebotsText", SanitizeString(pos.SonderwunschAngebotsText)));
 
                 foreach (var konfig in pos.Daten.Where(u => u.UnterkomponenteName == "Variante"))
                 {
@@ -205,6 +205,16 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
             result.Sektionen.Add(aktuelleSektion);
 
             return result;
+        }
+
+        private static string SanitizeString(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            return text.Replace("\r", "||").Replace("\n", "");
         }
     }
 }


### PR DESCRIPTION
We want to use `gSQLExporter` from NuGet package for all projects (IDAS repo and IBOS1 microservice already was changed some time ago to use NuGet package).

Yesterday I wanted to apply these changes for IBOS2 legacy and microservice, but our integration tests for microservice was failed. After some time of debugging, I found that order of some properties was changed in `gSQLExporter` from NuGet and we have this logic in IBOS2:

```csharp
for (var i = 0; i < posSektion.Items.Count; i++)
{
    var item = posSektion.Items[i];

    if (item.Name == "Position_PositionsNummer" ||
        item.Name == "Position_LaufendeNummer" ||
        item.Name == "Position_Nummer" ||
        item.Name == "Position_PositionsGuid")
    {
        inPos = false;
    }

    if (item.Name == "Position_PositionsGuid" &&
        item.Wert.Equals(posGuid.ToString(), StringComparison.InvariantCultureIgnoreCase))
    {
        inPos = true;
    }

    if (inPos)
    {
        // ... copy data to BelegPosition
    }
}
```

Here are the changes between GSQL generated by old `gSQLExporter` and new from NuGet:
![image](https://user-images.githubusercontent.com/905878/125775787-2ddeccf7-f2bb-4d87-8bd0-71632d75acd5.png)


Properties used in IBOS1:

- `Position_IstAktiv`
- `Position_IstAlternativPosition`

Not used properties in IBOS1 and IBOS2:

- `OriginalVorgangGuid`
- `Position_ProduktionZusatzInfo*`

so they can be skipped.

I also added string sanitization for `Position_Besonderheiten` and `Position_Einbauort` (these properties was sanitized in old `gSQLExporter` from IBOS2)