### PR TITLE
Add gSQLImporter

### DIFF
--- a/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLImporter.cs
+++ b/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLImporter.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Gandalan.IDAS.WebApi.Util.gSQL
+{
+    public class gSQLImporter
+    {
+        /// <summary>
+        /// Import from GSQL file
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="encoding">Use Encoding.Default if null</param>
+        /// <returns></returns>
+        public static gSQLInhalt ImportFromFile(string fileName, Encoding encoding = null)
+        {
+            if (encoding == null)
+            {
+                encoding = Encoding.Default;
+            }
+
+            if (!File.Exists(fileName))
+            {
+                throw new FileNotFoundException(fileName + " nicht gefunden");
+            }
+
+            var zeilen = File.ReadAllLines(fileName, encoding);
+            return Import(zeilen);
+        }
+
+        /// <summary>
+        /// Import from gSQLInhalt data
+        /// </summary>
+        /// <param name="gsqlData"></param>
+        /// <param name="encoding">Use Encoding.Default if null</param>
+        /// <returns></returns>
+        public static gSQLInhalt ImportFromGsql(gSQLInhalt gsqlData, Encoding encoding = null)
+        {
+            if (encoding == null)
+            {
+                encoding = Encoding.Default;
+            }
+
+            var stream = new MemoryStream(encoding.GetBytes(gsqlData.ToString()));
+
+            var zeilen = ReadLines(stream, encoding);
+            return Import(zeilen);
+        }
+
+        private static gSQLInhalt Import(IEnumerable<string> zeilen)
+        {
+            var result = new gSQLInhalt();
+            gSQLSektion aktuelleSektion = null;
+            var doppelPunktPosition = 60;
+
+            foreach (var zeile in zeilen)
+            {
+                if (string.IsNullOrEmpty(zeile.Trim()))
+                {
+                    continue;
+                }
+
+                if (!zeile.StartsWith(" "))
+                {
+                    aktuelleSektion = new gSQLSektion { Name = zeile.Trim() };
+                    result.Sektionen.Add(aktuelleSektion);
+                }
+                else if (aktuelleSektion != null)
+                {
+                    var zeileBereinigt = zeile.Trim();
+                    if (zeileBereinigt.StartsWith("DatenFormat"))
+                    {
+                        var format = zeileBereinigt.Substring(zeileBereinigt.IndexOf(':') + 1);
+                        if (format.StartsWith("gSQL"))
+                        {
+                            doppelPunktPosition = int.Parse(format.Replace("gSQL", ""));
+                        }
+                    }
+
+                    var itemName = zeile.Substring(0, doppelPunktPosition).Trim();
+                    var itemWert = zeile.Substring(doppelPunktPosition + 1).Trim();
+
+                    aktuelleSektion.Items.Add(new gSQLItem
+                    {
+                        Name = itemName,
+                        Wert = itemWert,
+                    });
+                }
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<string> ReadLines(Stream stream, Encoding encoding)
+        {
+            var lines = new List<string>();
+
+            using (var reader = new StreamReader(stream, encoding))
+            {
+                while (!reader.EndOfStream)
+                {
+                    lines.Add(reader.ReadLine());
+                }
+            }
+
+            return lines;
+        }
+    }
+}

--- a/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLImporter.cs
+++ b/Gandalan.IDAS.WebApi.Data/Util/gSQL/gSQLImporter.cs
@@ -34,7 +34,7 @@ namespace Gandalan.IDAS.WebApi.Util.gSQL
         /// <param name="gsqlData"></param>
         /// <param name="encoding">Use Encoding.Default if null</param>
         /// <returns></returns>
-        public static gSQLInhalt ImportFromGsql(gSQLInhalt gsqlData, Encoding encoding = null)
+        public static gSQLInhalt ImportFromGsqlInhalt(gSQLInhalt gsqlData, Encoding encoding = null)
         {
             if (encoding == null)
             {


### PR DESCRIPTION
`gsqlImporter` is used in IBOS2 (Legacy and microservice) and in `IDAS.Backend`