### PR TITLE
Remove `I1Url` and `I2Url`

### DIFF
--- a/Gandalan.IDAS.Client.Contracts/Contracts/IWebApiConfig.cs
+++ b/Gandalan.IDAS.Client.Contracts/Contracts/IWebApiConfig.cs
@@ -33,17 +33,9 @@ namespace Gandalan.IDAS.Client.Contracts.Contracts
         /// </summary>
         string CMSUrl { get; set; }
         /// <summary>
-        /// Latex-Reports 
+        /// Latex-Reports
         /// </summary>
         string LatexReportUrl { get; set; }
-        /// <summary>
-        /// IBOS2-Varianten Produktionsberechnung 
-        /// </summary>
-        string I2Url { get; set; }
-        /// <summary>
-        /// IBOS1-Varianten Produktionsberechnung 
-        /// </summary>
-        string I1Url { get; set; }
 
         void Save();
 

--- a/Gandalan.IDAS.WebApi.Client/Settings/HubResponse.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/HubResponse.cs
@@ -5,8 +5,6 @@
         public string CMS { get; set; }
         public string DOCS { get; set; }
         public string IDAS { get; set; }
-        public string Prod_I1 { get; set; }
-        public string Prod_I2 { get; set; }
         public string Print_Latex { get; set; }
     }
 }

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiFileConfig.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiFileConfig.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Gandalan.IDAS.Client.Contracts.Contracts;
+﻿using Gandalan.IDAS.Client.Contracts.Contracts;
 using Gandalan.IDAS.WebApi.DTO;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Gandalan.IDAS.WebApi.Client.Settings
 {
@@ -23,7 +23,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             setupEnvironments(appToken);
             setupLocalEnvironment(appToken);
         }
-        
+
         public static IWebApiConfig ByName(string name)
         {
             if (_settings.ContainsKey(name))
@@ -75,8 +75,6 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                             Url = response.IDAS,
                             CMSUrl = response.CMS,
                             DocUrl = response.DOCS,
-                            I1Url = response.Prod_I1,
-                            I2Url = response.Prod_I2, 
                             LatexReportUrl = response.Print_Latex,
                             FriendlyName = env,
                             AppToken = appToken
@@ -107,7 +105,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                 environment.UserName = savedAuthToken.UserName;
             }
         }
-        
+
         private static SavedAuthToken internalLoadSavedAuthToken(string env)
         {
             string configFile = Path.Combine(_settingsPath, env, "AuthToken_" + _appTokenString + ".json");
@@ -132,7 +130,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
 
         internal static void Save(IWebApiConfig settings)
         {
-            if (settings == null) 
+            if (settings == null)
                 return;
 
             string configPath = Path.Combine(_settingsPath, settings.FriendlyName);

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using Gandalan.IDAS.Client.Contracts.Contracts;
+﻿using Gandalan.IDAS.Client.Contracts.Contracts;
 using Gandalan.IDAS.WebApi.Client.Discovery;
 using Gandalan.IDAS.WebApi.DTO;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace Gandalan.IDAS.WebApi.Client.Settings
 {
@@ -37,17 +37,9 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
         /// </summary>
         public string CMSUrl { get; set; }
         /// <summary>
-        /// Latex-Reports 
+        /// Latex-Reports
         /// </summary>
         public string LatexReportUrl { get; set; }
-        /// <summary>
-        /// IBOS2-Varianten Produktionsberechnung 
-        /// </summary>
-        public string I2Url { get; set; }
-        /// <summary>
-        /// IBOS1-Varianten Produktionsberechnung 
-        /// </summary>
-        public string I1Url { get; set; }
 
         public WebApiSettings(Guid appToken, string env)
         {
@@ -82,8 +74,6 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             this.UserName = settings.UserName;
             this.InstallationId = settings.InstallationId;
             this.UserAgent = settings.UserAgent;
-            this.I1Url = settings.I1Url;
-            this.I2Url = settings.I2Url;
         }
 
 


### PR DESCRIPTION
`I1Url` and `I2Url` are not needed in current `AVBerechnung` implementation

DO NOT MERGE before tomorrow's release!

@gdl-reif: Where we have URLs for microservices? I could not find it in Client and Backend solutions. I found only `IBOS1SERVICEURL` and `IBOS2SERVICEURL`, but they are new env variables used in new `AVBerechnung` implementation