### PR TITLE
Change `OberFlaeche` to `OberflaecheBezeichnung`

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/DTOs/PositionsDaten/PositionsDatenDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/PositionsDaten/PositionsDatenDTO.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Gandalan.IDAS.WebApi.DTO
 {
@@ -29,7 +27,7 @@ namespace Gandalan.IDAS.WebApi.DTO
         public Guid FarbItemGuid { get; set; }
         public string FarbCode { get; set; }
         public string FarbBezeichnung { get; set; }
-        public string Oberflaeche { get; set; }
+        public string OberflaecheBezeichnung { get; set; }
         public Guid OberflaecheGuid { get; set; }
         public bool IstSonderFarbPosition { get; set; }
         public string Gewebe { get; set; }
@@ -40,7 +38,7 @@ namespace Gandalan.IDAS.WebApi.DTO
         public string VorgangsNummer { get; set; }
         public string DruckDatum { get; set; }
         public string VersandAdresse { get; set; }
-        
+
         public string DataErstellDatum { get; set; }
         public string BelegNummer { get; set; }
         public string BelegJahr { get; set; }

--- a/Gandalan.IDAS.WebApi.Client/DTOs/Produktion/MaterialbedarfDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Produktion/MaterialbedarfDTO.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Gandalan.IDAS.WebApi.DTO
 {
@@ -32,12 +28,12 @@ namespace Gandalan.IDAS.WebApi.DTO
         public bool Beipacken { get; set; }
 
         /// <summary>
-        /// Anzahl des Artikels (gleiche Artikel werden per Standard nicht zusammengefasst; schließt 
+        /// Anzahl des Artikels (gleiche Artikel werden per Standard nicht zusammengefasst; schließt
         /// sich aus mit Laufmeter!)
         /// </summary>
         public decimal Stueckzahl { get; set; }
         /// <summary>
-        /// Laufmeter des Artikels (gleiche Artikel werden per Standard nicht zusammengefasst; schließt 
+        /// Laufmeter des Artikels (gleiche Artikel werden per Standard nicht zusammengefasst; schließt
         /// sich aus mit Stückzahl!)
         /// </summary>
         public decimal Laufmeter { get; set; }
@@ -58,11 +54,11 @@ namespace Gandalan.IDAS.WebApi.DTO
         public string FarbeItem { get; set; }
         public Guid FarbItemGuid { get; set; }
 
-        public string OberFlaeche { get; set; }
+        public string OberflaecheBezeichnung { get; set; }
         public Guid OberFlaecheGuid { get; set; }
 
         /// <summary>
-        /// Kennzeichen für Zuschnittartikel 
+        /// Kennzeichen für Zuschnittartikel
         /// </summary>
         public bool IstZuschnitt { get; set; }
         public float ZuschnittLaenge { get; set; }


### PR DESCRIPTION
Bug reported by Rene.

Change `OberFlaeche` to `OberflaecheBezeichnung` in `MaterialbedarfDTO` and `PositionsDatenDTO`.

`OberflaecheBezeichnung` property was introduced in VB6 by Gerhard since 2022.01.11 but is still missing in NuGet