### PR TITLE
Fix NuGet CI - don't push duplicated `nupkg` files

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish (NuGet)
 
 on:
   push:
-    #branches: [ master ]
+    branches: [ master ]
     paths-ignore:
       - 'WebLibs/**'
 
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-publish:
-    #if: github.repository_owner == 'gandalan'
+    if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,10 +53,10 @@ jobs:
       run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_4 }}
       run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
-    #- name: Push packages
-      #run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
-      #env:
-        #NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+    - name: Push packages
+      run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
+      env:
+        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
     - name: Create tag
       uses: rickstaa/action-create-tag@v1
       with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish (NuGet)
 
 on:
   push:
-    branches: [ master ]
+    #branches: [ master ]
     paths-ignore:
       - 'WebLibs/**'
 
@@ -17,10 +17,11 @@ env:
   PACKAGE_4: GDL.IDAS.WebApi.Client.Wpf
   PACKAGE_4_FULL: Gandalan.IDAS.WebApi.Client.Wpf
   BUILD_CONFIG: Release
+  OUTPUT_DIR: ./GDLPackages
 
 jobs:
   build-and-publish:
-    if: github.repository_owner == 'gandalan'
+    #if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +31,7 @@ jobs:
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
-    - name: Set release_name
+    - name: 'Set release_name: ${{ steps.set_release_name.outputs.release_name }}'
       id: set_release_name
       run: echo "::set-output name=release_name::$(date +'%-Y.%-m.%-d').$GITHUB_RUN_NUMBER"
     - name: Setup .NET Core SDK ${{ env.SDK_VERSION }}
@@ -45,17 +46,17 @@ jobs:
     - name: Build
       run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore -p:Version=${{ steps.set_release_name.outputs.release_name }}
     - name: Create package ${{ env.PACKAGE_1 }}
-      run: nuget pack ${{ env.PACKAGE_1_FULL }}/${{ env.PACKAGE_1 }}.nuspec -NonInteractive -Verbosity Detailed
+      run: nuget pack ${{ env.PACKAGE_1_FULL }}/${{ env.PACKAGE_1 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
     - name: Create package ${{ env.PACKAGE_2 }}
-      run: nuget pack ${{ env.PACKAGE_2_FULL }}/${{ env.PACKAGE_2 }}.nuspec -NonInteractive -Verbosity Detailed
+      run: nuget pack ${{ env.PACKAGE_2_FULL }}/${{ env.PACKAGE_2 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
     - name: Create package ${{ env.PACKAGE_3 }}
-      run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed
+      run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
     - name: Create package ${{ env.PACKAGE_4 }}
-      run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed
-    - name: Push packages
-      run: dotnet nuget push "**/*.nupkg" -k ${NUGET_TOKEN} --skip-duplicate
-      env:
-        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+      run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
+    #- name: Push packages
+      #run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
+      #env:
+        #NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
     - name: Create tag
       uses: rickstaa/action-create-tag@v1
       with:
@@ -72,6 +73,6 @@ jobs:
     - name: Upload Assets to Release with a wildcard
       uses: csexton/release-asset-action@v2
       with:
-        pattern: "**/*.nupkg"
+        pattern: "${{ env.OUTPUT_DIR }}/*.nupkg"
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1
-    - name: 'Set release_name: ${{ steps.set_release_name.outputs.release_name }}'
+    - name: Set release_name
       id: set_release_name
       run: echo "::set-output name=release_name::$(date +'%-Y.%-m.%-d').$GITHUB_RUN_NUMBER"
     - name: Setup .NET Core SDK ${{ env.SDK_VERSION }}
@@ -46,13 +46,13 @@ jobs:
     - name: Build
       run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore -p:Version=${{ steps.set_release_name.outputs.release_name }}
     - name: Create package ${{ env.PACKAGE_1 }}
-      run: nuget pack ${{ env.PACKAGE_1_FULL }}/${{ env.PACKAGE_1 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
+      run: nuget pack ${{ env.PACKAGE_1_FULL }}/${{ env.PACKAGE_1 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_2 }}
-      run: nuget pack ${{ env.PACKAGE_2_FULL }}/${{ env.PACKAGE_2 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
+      run: nuget pack ${{ env.PACKAGE_2_FULL }}/${{ env.PACKAGE_2 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_3 }}
-      run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
+      run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_4 }}
-      run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory OUTPUT_DIR
+      run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     #- name: Push packages
       #run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
       #env:

--- a/.github/workflows/publish-weblibs.yml
+++ b/.github/workflows/publish-weblibs.yml
@@ -18,6 +18,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PACKAGEJSON_DIR: ${{ env.WEBLIBS_DIR }}
+        tag-prefix:  WebLibs_
+        commit-message: 'CI: WebLibs version bump to {{version}}'
     # Setup .npmrc file to publish to npm
     - uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Create NuGet packages in different directory and change patterns to not upload duplicated files.

Better tag and commit message for WebLibs version bump.