### PR TITLE
NoWarn for `CS1591` in Release configuration

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish (NuGet)
 
 on:
   push:
-    #branches: [ master ]
+    branches: [ master ]
     paths-ignore:
       - 'WebLibs/**'
 
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-publish:
-    #if: github.repository_owner == 'gandalan'
+    if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,10 +53,10 @@ jobs:
       run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_4 }}
       run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
-    #- name: Push packages
-      #run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
-      #env:
-        #NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+    - name: Push packages
+      run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
+      env:
+        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
     - name: Create tag
       uses: rickstaa/action-create-tag@v1
       with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Build and publish (NuGet)
 
 on:
   push:
-    branches: [ master ]
+    #branches: [ master ]
     paths-ignore:
       - 'WebLibs/**'
 
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-publish:
-    if: github.repository_owner == 'gandalan'
+    #if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 
     steps:
@@ -53,10 +53,10 @@ jobs:
       run: nuget pack ${{ env.PACKAGE_3_FULL }}/${{ env.PACKAGE_3 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
     - name: Create package ${{ env.PACKAGE_4 }}
       run: nuget pack ${{ env.PACKAGE_4_FULL }}/${{ env.PACKAGE_4 }}.nuspec -NonInteractive -Verbosity Detailed -OutputDirectory ${{ env.OUTPUT_DIR }}
-    - name: Push packages
-      run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
-      env:
-        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+    #- name: Push packages
+      #run: dotnet nuget push "${{ env.OUTPUT_DIR }}/*.nupkg" -k ${NUGET_TOKEN} #--skip-duplicate
+      #env:
+        #NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
     - name: Create tag
       uses: rickstaa/action-create-tag@v1
       with:

--- a/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
+++ b/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
@@ -15,6 +15,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Crypto\GDL.IDAS.Crypto.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
+++ b/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
@@ -15,5 +15,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Logging\GDL.IDAS.Logging.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.WebApi.Client.Wpf\GDL.IDAS.WebApi.Client.Wpf.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\Neher\Logo.png" />

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -15,6 +15,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.WebApi.Client\GDL.IDAS.WebApi.Client.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Don't show `CS1591` warnings for Release build like:

```
warning CS1591: Missing XML comment for publicly visible type or member 'IVariantenService.SaveAsync(VarianteDTO)'
```

This will also speed up build a little and fix too long output in GitHub Actions:
![image](https://user-images.githubusercontent.com/905878/171141145-7ea7e3de-94cb-4628-9ef3-511d06b36cd2.png)


### Before

```
    23397 Warning(s)
    0 Error(s)

Time Elapsed 00:00:23.81
```

### After

```
    135 Warning(s)
    0 Error(s)

Time Elapsed 00:00:21.34
```