### PR TITLE
Fix `gh-action-bump-version` parameters

### DIFF
--- a/.github/workflows/publish-weblibs.yml
+++ b/.github/workflows/publish-weblibs.yml
@@ -18,6 +18,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PACKAGEJSON_DIR: ${{ env.WEBLIBS_DIR }}
+      with:
         tag-prefix:  WebLibs_
         commit-message: 'CI: WebLibs version bump to {{version}}'
     # Setup .npmrc file to publish to npm


### PR DESCRIPTION
Addendum to 4d3a37b1863455b9f2938278e6c157e15a39badc