### PR TITLE
Ignore `publish-weblibs.yml` for NuGet workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
     paths-ignore:
       - 'WebLibs/**'
+      - '.github/workflows/publish-weblibs.yml'
 
 env:
   SDK_VERSION: 6.0.x


### PR DESCRIPTION
Last Pull Request for `publish-weblibs.yml` (https://github.com/gandalan/idas-client-libs/pull/122) created release for NuGet