### PR TITLE
Publish NPM WebLibs after push instead of manually `workflow_dispatch`

### DIFF
--- a/.github/workflows/publish-weblibs.yml
+++ b/.github/workflows/publish-weblibs.yml
@@ -1,6 +1,11 @@
 name: Publish WebLibs (NPM)
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'WebLibs/**'
+      - '.github/workflows/publish-weblibs.yml'
 
 env:
   WEBLIBS_DIR: WebLibs


### PR DESCRIPTION
This same trigger as in NuGet workflow