### PR TITLE
Add GanTable into index

### DIFF
--- a/WebLibs/index.js
+++ b/WebLibs/index.js
@@ -1,13 +1,14 @@
 import AddButton from './components/AddButton.svelte';
 import DataGrid from './components/DataGrid.svelte';
 import Dialog from './components/Dialog.svelte';
+import GanTable from './components/GanTable.svelte';
 import Datepicker from './components/Datepicker.svelte';
 import Inputbox from './components/Inputbox.svelte';
 import RemoveButton from './components/RemoveButton.svelte';
 import SaveButton from './components/SaveButton.svelte';
 
 export {
-    DataGrid, Datepicker, Inputbox, Dialog,
+    DataGrid, Datepicker, Inputbox, Dialog, GanTable,
     AddButton, RemoveButton, SaveButton
 }
 


### PR DESCRIPTION
Hopefully it will fix warning from `svelte-check`:

```
Could not find a declaration file for module '@gandalan/weblibs/components/GanTable.svelte'.
'C:/Gandalan/IDAS/Source/Server/IDASDataIntegrityCheck/node_modules/@gandalan/weblibs/components/GanTable.svelte' implicitly has an 'any' type.
```