### PR TITLE
Fix NRE in `RESTClientBase`. `AddInfoToException()`

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
@@ -6,14 +6,14 @@
 // Edit: phil - 21.02.2017
 // *****************************************************************************
 
+using Gandalan.IDAS.Client.Contracts.Contracts;
+using Gandalan.IDAS.Web;
+using Gandalan.IDAS.WebApi.Client.Settings;
+using Gandalan.IDAS.WebApi.DTO;
+using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Gandalan.IDAS.WebApi.Client.Settings;
-using Gandalan.IDAS.WebApi.DTO;
-using Gandalan.IDAS.Web;
-using Newtonsoft.Json;
-using Gandalan.IDAS.Client.Contracts.Contracts;
 
 namespace Gandalan.IDAS.WebApi.Client
 {
@@ -74,7 +74,7 @@ namespace Gandalan.IDAS.WebApi.Client
         }
 
         /// <summary>
-        /// Meldet mit den aktuellen Credentials am Endpunkt /api/Login/Authenticate an. Wenn ein AuthToken vorhanden ist, wird 
+        /// Meldet mit den aktuellen Credentials am Endpunkt /api/Login/Authenticate an. Wenn ein AuthToken vorhanden ist, wird
         /// zunächst versucht, dieses zu verwenden und ggf. zu updaten. Wenn das fehlschlägt, erfolgt eine Anmeldung mit Username/
         /// Passwort aus den Settings.
         /// </summary>
@@ -113,12 +113,10 @@ namespace Gandalan.IDAS.WebApi.Client
                     Status = "OK";
                     return true;
                 }
-                else
-                {
-                    AuthToken = null;
-                    Status = "Error";
-                    return false;
-                }
+
+                AuthToken = null;
+                Status = "Error";
+                return false;
             }
             catch (ApiException apiex)
             {
@@ -175,12 +173,10 @@ namespace Gandalan.IDAS.WebApi.Client
                     Status = "OK";
                     return true;
                 }
-                else
-                {
-                    AuthToken = null;
-                    Status = "Error";
-                    return false;
-                }
+
+                AuthToken = null;
+                Status = "Error";
+                return false;
             }
             catch (ApiException apiex)
             {
@@ -202,7 +198,6 @@ namespace Gandalan.IDAS.WebApi.Client
                 return false;
             }
         }
-
 
         public UserAuthTokenDTO RefreshToken(Guid authTokenGuid)
         {
@@ -234,26 +229,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Post<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -264,26 +246,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PostAsync<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -294,26 +263,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Post(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -324,26 +280,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PostAsync(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -354,26 +297,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.PostData(uri, data);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -384,26 +314,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PostDataAsync(uri, data);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -414,26 +331,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Get(uri);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -444,26 +348,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.GetAsync(uri);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -474,26 +365,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.GetData(uri);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -504,26 +382,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.GetDataAsync(uri);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -534,26 +399,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Get<T>(uri, settings);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -564,26 +416,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.GetAsync<T>(uri, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -594,26 +433,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Put<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex, data);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -624,26 +450,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PutAsync<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -654,26 +467,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Put(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex, data);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -684,26 +484,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PutAsync(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -714,26 +501,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.PutData(uri, data);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -744,56 +518,30 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.PutDataAsync(uri, data);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex, data);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
 
-        public T Delete<T>(string uri, object data, JsonSerializerSettings settings = null) 
+        public T Delete<T>(string uri, object data, JsonSerializerSettings settings = null)
         {
             using (var cl = new RESTRoutinen(Settings.Url))
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Delete<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex, data);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -804,56 +552,30 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.DeleteAsync<T>(uri, data, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex, data);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
 
-        public T Delete<T>(string uri, JsonSerializerSettings settings = null) 
+        public T Delete<T>(string uri, JsonSerializerSettings settings = null)
         {
             using (var cl = new RESTRoutinen(Settings.Url))
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Delete<T>(uri, settings);
                 }
                 catch (WebException ex)
                 {
-                        ApiException exception = TranslateException(ex);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -864,26 +586,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.DeleteAsync<T>(uri, settings);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -894,26 +603,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return cl.Delete(uri);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                        if (!IgnoreOnErrorOccured)
-                        {
-                            OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                        }
-
-                        throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -924,26 +620,13 @@ namespace Gandalan.IDAS.WebApi.Client
             {
                 try
                 {
-                    if (AuthToken != null)
-                    {
-                        cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
-                    }
-                    if (Settings.InstallationId != Guid.Empty)
-                        cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
-                    if (!String.IsNullOrEmpty(Settings.UserAgent))
-                        cl.UserAgent = Settings.UserAgent;
+                    SetupRestRoutinen(cl);
 
                     return await cl.DeleteAsync(uri);
                 }
                 catch (WebException ex)
                 {
-                    ApiException exception = TranslateException(ex);
-                    if (!IgnoreOnErrorOccured)
-                    {
-                        OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
-                    }
-
-                    throw exception;
+                    throw HandleWebException(ex);
                 }
             }
         }
@@ -959,6 +642,35 @@ namespace Gandalan.IDAS.WebApi.Client
                     result = $"Interner Serverfehler (\"{result.Substring(start, end - start)}\"). Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.";
             }
             return result;
+        }
+
+        private void SetupRestRoutinen(RESTRoutinen cl)
+        {
+            if (AuthToken != null)
+            {
+                cl.AdditionalHeaders.Add("X-Gdl-AuthToken: " + AuthToken.Token);
+            }
+
+            if (Settings.InstallationId != Guid.Empty)
+            {
+                cl.AdditionalHeaders.Add("X-Gdl-InstallationId: " + Settings.InstallationId);
+            }
+
+            if (!string.IsNullOrEmpty(Settings.UserAgent))
+            {
+                cl.UserAgent = Settings.UserAgent;
+            }
+        }
+
+        private ApiException HandleWebException(WebException ex)
+        {
+            ApiException exception = TranslateException(ex);
+            if (!IgnoreOnErrorOccured)
+            {
+                OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
+            }
+
+            return exception;
         }
     }
 }

--- a/Gandalan.IDAS.WebApi.Client/RESTClientBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTClientBase.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.IO;
 using System.Net;
-using Newtonsoft.Json;
 
 namespace Gandalan.IDAS.Web
 {
@@ -13,25 +13,30 @@ namespace Gandalan.IDAS.Web
             {
                 HttpStatusCode code = (ex.Response as HttpWebResponse).StatusCode;
                 string info = new StreamReader((ex.Response as HttpWebResponse).GetResponseStream()).ReadToEnd();
-                try
-                {
-                    Exception original = JsonConvert.DeserializeObject<Exception>(info, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
-                    return new ApiException(original.Message, code, original, payload);
-                }
-                catch
+
+                if (!string.IsNullOrWhiteSpace(info))
                 {
                     try
                     {
-                        dynamic infoObject = JsonConvert.DeserializeObject<dynamic>(info);
-                        string status = infoObject.status;
-                        return new ApiException(status, code, payload) { ExceptionString = infoObject.exception.ToString() };
+                        Exception original = JsonConvert.DeserializeObject<Exception>(info, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
+                        return new ApiException(original.Message, code, original, payload);
                     }
                     catch
                     {
-                        return new ApiException(info, code, payload);
+                        try
+                        {
+                            dynamic infoObject = JsonConvert.DeserializeObject<dynamic>(info);
+                            string status = infoObject.status;
+                            return new ApiException(status, code, payload) { ExceptionString = infoObject.exception.ToString() };
+                        }
+                        catch
+                        {
+                            return new ApiException(info, code, payload);
+                        }
                     }
                 }
             }
+
             return new ApiException(ex.Message, ex, payload);
         }
 
@@ -41,25 +46,30 @@ namespace Gandalan.IDAS.Web
             {
                 HttpStatusCode code = (ex.Response as HttpWebResponse).StatusCode;
                 string info = new StreamReader((ex.Response as HttpWebResponse).GetResponseStream()).ReadToEnd();
-                try
-                {
-                    Exception original = JsonConvert.DeserializeObject<Exception>(info, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
-                    return new ApiException(original.Message, code, original);
-                }
-                catch
+
+                if (!string.IsNullOrWhiteSpace(info))
                 {
                     try
                     {
-                        dynamic infoObject = JsonConvert.DeserializeObject<dynamic>(info);
-                        string status = infoObject.status;
-                        return new ApiException(status, code) { ExceptionString = infoObject.exception.ToString() };
+                        Exception original = JsonConvert.DeserializeObject<Exception>(info, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
+                        return new ApiException(original.Message, code, original);
                     }
                     catch
                     {
-                        return new ApiException(info, code);
+                        try
+                        {
+                            dynamic infoObject = JsonConvert.DeserializeObject<dynamic>(info);
+                            string status = infoObject.status;
+                            return new ApiException(status, code) { ExceptionString = infoObject.exception.ToString() };
+                        }
+                        catch
+                        {
+                            return new ApiException(info, code);
+                        }
                     }
                 }
             }
+
             return new ApiException(ex.Message, ex);
         }
     }

--- a/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
@@ -1,13 +1,14 @@
 ﻿using Newtonsoft.Json;
-using System.Net;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Gandalan.IDAS.Web
 {
     /// <summary>
-    /// Klasse für den HTTP-Datentransfer per REST an unsere WebAPIs. Ermöglicht das Senden 
+    /// Klasse für den HTTP-Datentransfer per REST an unsere WebAPIs. Ermöglicht das Senden
     /// und Empfangen von Objekten. Die Übermittlung erfolgt mit JSON serialisierten Objekten.
     /// </summary>
     public class RESTRoutinen : IDisposable
@@ -32,7 +33,7 @@ namespace Gandalan.IDAS.Web
 
         #region public Properties
         /// <summary>
-        /// Stammadresse der Web-API. Die Resource-Parameter der einzelnen Übertragungsmethoden 
+        /// Stammadresse der Web-API. Die Resource-Parameter der einzelnen Übertragungsmethoden
         /// werden angehängt. Beispiel: http://192.168.217.10/neurosAPI/api/
         /// </summary>
         public string BaseUrl { get; set; }
@@ -41,7 +42,7 @@ namespace Gandalan.IDAS.Web
         /// </summary>
         public IWebProxy Proxy { get; set; }
         /// <summary>
-        /// Liste der zusätzlich zu übermittelnden Header. Werden bei jeder Anfrage mitgeschickt, 
+        /// Liste der zusätzlich zu übermittelnden Header. Werden bei jeder Anfrage mitgeschickt,
         /// z.B. für Authentifizierungs-Header
         /// </summary>
         public List<string> AdditionalHeaders { get; private set; }
@@ -54,7 +55,7 @@ namespace Gandalan.IDAS.Web
 
         #region public Methods
         /// <summary>
-        /// Holt ein Objekt per HTTP GET 
+        /// Holt ein Objekt per HTTP GET
         /// </summary>
         /// <typeparam name="T">Typsierungsparameter</typeparam>
         /// <param name="url">Relative URL, bezogen auf die BaseUrl</param>
@@ -62,14 +63,14 @@ namespace Gandalan.IDAS.Web
         /// <returns>Objektinstanz</returns>
         public T Get<T>(string url, JsonSerializerSettings settings = null)
         {
-            WebClient client = createWebClient();
             try
             {
                 return JsonConvert.DeserializeObject<T>(Get(url), settings);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -78,14 +79,14 @@ namespace Gandalan.IDAS.Web
 
         public async Task<T> GetAsync<T>(string url, JsonSerializerSettings settings = null)
         {
-            WebClient client = createWebClient();
             try
             {
                 return JsonConvert.DeserializeObject<T>(await GetAsync(url), settings);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -99,9 +100,10 @@ namespace Gandalan.IDAS.Web
             {
                 return client.DownloadString(url);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -115,9 +117,10 @@ namespace Gandalan.IDAS.Web
             {
                 return await client.DownloadStringTaskAsync(url).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -131,9 +134,10 @@ namespace Gandalan.IDAS.Web
             {
                 return client.DownloadData(url);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -147,16 +151,17 @@ namespace Gandalan.IDAS.Web
             {
                 return await client.DownloadDataTaskAsync(url).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
             #endregion
         }
         /// <summary>
-        /// Sendet ein Objekt per HTTP POST an die angegebene URL, i.d.R. um es zu speichern 
+        /// Sendet ein Objekt per HTTP POST an die angegebene URL, i.d.R. um es zu speichern
         /// </summary>
         /// <typeparam name="T">Typisierungsparameter</typeparam>
         /// <param name="url">Relative URL, bezogen auf die BaseUrl</param>
@@ -181,8 +186,9 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return client.UploadString(url, "POST", json);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -196,14 +202,13 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return await client.UploadStringTaskAsync(url, "POST", json).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
         }
-
-
 
         public byte[] PostData(string url, byte[] data)
         {
@@ -212,9 +217,10 @@ namespace Gandalan.IDAS.Web
             {
                 return client.UploadData(url, "POST", data);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -228,9 +234,10 @@ namespace Gandalan.IDAS.Web
             {
                 return await client.UploadDataTaskAsync(url, "POST", data).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -263,8 +270,9 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return client.UploadString(url, "PUT", json);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -278,8 +286,9 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return await client.UploadStringTaskAsync(url, "PUT", json).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -292,9 +301,10 @@ namespace Gandalan.IDAS.Web
             {
                 return client.UploadData(url, "PUT", data);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -308,9 +318,10 @@ namespace Gandalan.IDAS.Web
             {
                 return await client.UploadDataTaskAsync(url, "PUT", data).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             #region Code
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -329,8 +340,9 @@ namespace Gandalan.IDAS.Web
             {
                 return client.UploadString(url, "DELETE", "");
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -343,8 +355,9 @@ namespace Gandalan.IDAS.Web
             {
                 return await client.UploadStringTaskAsync(url, "DELETE", "").ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -391,8 +404,9 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return client.UploadString(url, "DELETE", json);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -406,8 +420,9 @@ namespace Gandalan.IDAS.Web
                 string json = JsonConvert.SerializeObject(data, settings);
                 return await client.UploadStringTaskAsync(url, "DELETE", json).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
+                AddInfoToException(ex, url, GetCurrentMethodName());
                 // Für Diagnosezwecke wird hier gefangen und weitergeworfen
                 throw;
             }
@@ -416,7 +431,7 @@ namespace Gandalan.IDAS.Web
 
         #region private Methods
         /// <summary>
-        /// Erstellt und konfiguriert eine neue WebClient-Instanz 
+        /// Erstellt und konfiguriert eine neue WebClient-Instanz
         /// </summary>
         /// <returns></returns>
         private WebClient createWebClient()
@@ -436,9 +451,24 @@ namespace Gandalan.IDAS.Web
             return client;
         }
 
+        private void AddInfoToException(Exception ex, string url, string callMethod)
+        {
+            ex.Data.Add("BaseUrl", BaseUrl);
+            ex.Data.Add("URL", url);
+            ex.Data.Add("CallMethod", callMethod);
+        }
+
+        public static string GetCurrentMethodName()
+        {
+            var stackTrace = new StackTrace();
+            var stackFrame = stackTrace.GetFrame(1);
+
+            return stackFrame?.GetMethod()?.Name;
+        }
+        #endregion
+
         public void Dispose()
         {
         }
-        #endregion
     }
 }


### PR DESCRIPTION
BaseUrl, Url and CallMethod

Previously, we could not easily see which API call caused `ApiException`:
![image](https://user-images.githubusercontent.com/905878/185966894-12df2981-dd93-42e4-af11-441258de7545.png)

Now we can see this (this screenshot is not from the final version of this PR, I have problems with VS and I can't build i3 Client anymore...):
![image](https://user-images.githubusercontent.com/905878/185967206-e3bb73d3-9d8a-4174-a943-5228cb7a703b.png)