### PR TITLE
Fix infinite loop in `InternalHandleWebException`

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -22,7 +22,7 @@ env:
   OUTPUT_DIR: ./GDLPackages
 
 jobs:
-  build-and-publish:
+  build-and-publish-nuget:
     if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-NuGet-Libs.yml
+++ b/.github/workflows/check-NuGet-Libs.yml
@@ -22,7 +22,7 @@ env:
   OUTPUT_DIR: ./GDLPackages
 
 jobs:
-  build-and-publish:
+  check-nuget-libs:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-weblibs.yml
+++ b/.github/workflows/publish-weblibs.yml
@@ -11,7 +11,7 @@ env:
   WEBLIBS_DIR: WebLibs
 
 jobs:
-  build-and-publish:
+  build-and-publish-weblibs:
     if: github.repository_owner == 'gandalan'
     runs-on: ubuntu-latest
 

--- a/Gandalan.IDAS.Logging/Logging/L.cs
+++ b/Gandalan.IDAS.Logging/Logging/L.cs
@@ -13,24 +13,26 @@ namespace Gandalan.IDAS.Logging
         public static void Fehler(Exception ex, string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
             Fehler($"{message} {ex.GetType().FullName}: {ex.Message}{Environment.NewLine}Stacktrace: {ex.StackTrace}", context, sender);
-            if (ex is AggregateException exception)
+
+            var innerException = ex.InnerException;
+            while (innerException != null)
             {
-                foreach (var e in exception.InnerExceptions)
-                {
-                    Fehler(e, $"{message} InnerException", context, sender);
-                }
+                Fehler(innerException, $"{message} InnerException", context, sender);
+
+                innerException = innerException.InnerException;
             }
         }
 
         public static void Fehler(Exception ex, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
             Fehler($"{ex.GetType().FullName}: {ex.Message}{Environment.NewLine}Stacktrace: {ex.StackTrace}", context, sender);
-            if (ex is AggregateException exception)
+
+            var innerException = ex.InnerException;
+            while (innerException != null)
             {
-                foreach (var e in exception.InnerExceptions)
-                {
-                    Fehler(e, "InnerException", context, sender);
-                }
+                Fehler(innerException, "InnerException", context, sender);
+
+                innerException = innerException.InnerException;
             }
         }
 

--- a/Gandalan.IDAS.WebApi.Client.Wpf/GDL.IDAS.WebApi.Client.Wpf.nuspec
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/GDL.IDAS.WebApi.Client.Wpf.nuspec
@@ -15,7 +15,7 @@
         </dependencies>
     </metadata>
     <files>
-       <file src="bin\Release\net48\GDL.IDAS.WebApi.Client.Wpf.dll" target="lib\net48\GDL.IDAS.WebApi.Client.Wpf.dll" />
+      <file src="bin\Release\net48\GDL.IDAS.WebApi.Client.Wpf.dll" target="lib\net48\GDL.IDAS.WebApi.Client.Wpf.dll" />
       <file src="bin\Release\net48\GDL.IDAS.WebApi.Client.Wpf.XML" target="lib\net48\GDL.IDAS.WebApi.Client.Wpf.XML" />
       <file src="bin\Release\net472\GDL.IDAS.WebApi.Client.Wpf.dll" target="lib\net472\GDL.IDAS.WebApi.Client.Wpf.dll" />
       <file src="bin\Release\net472\GDL.IDAS.WebApi.Client.Wpf.XML" target="lib\net472\GDL.IDAS.WebApi.Client.Wpf.XML" />

--- a/Gandalan.IDAS.WebApi.Client/GDL.IDAS.WebApi.Client.nuspec
+++ b/Gandalan.IDAS.WebApi.Client/GDL.IDAS.WebApi.Client.nuspec
@@ -11,6 +11,7 @@
         <copyright>Copyright © Gandalan GmbH &amp; Co. KG 2012-2020</copyright>
         <license type="expression">MIT</license>
         <dependencies>
+          <dependency id="GDL.IDAS.Logging" version="BUILDVERSION" />
           <dependency id="Newtonsoft.Json" version="13.0.1" />
         </dependencies>
     </metadata>

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="PropertyChanged.Fody" Version="3.4.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Gandalan.IDAS.Logging\Gandalan.IDAS.Logging.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
1. `WebRoutinenBase.cs`: Fix infinite loop
2. `WebRoutinenBase.cs`: Not every exception is caught by i3 Client, so log it here with exception data (URL, caller method)
3. `L.cs`: Sometimes exception have inner exceptions, but is not `AggregateException`