### PR TITLE
IDAS.authenticateWithJwt() fixes

### DIFF
--- a/WebLibs/api/IDAS.js
+++ b/WebLibs/api/IDAS.js
@@ -26,6 +26,11 @@ export class IDAS {
         return data;
     }
 
+    authorizeWithJwt(jwtToken) {
+        localStorage.setItem('IDAS_AuthJwtToken', jwtToken);
+        restClient = new RESTClient(apiBaseUrl, jwtToken, true);
+    }
+
     async authenticateWithSSO(forceRenew = false) { 
         if (!authToken)
         {
@@ -42,16 +47,20 @@ export class IDAS {
         }
     }
 
-    async authenticateWithJwt() {
+    async authenticateWithJwt(authPath) {
         if (!authJwtToken) {
+            const authEndpoint = (new URL(window.location.href).origin) + authPath;
+            let authUrlCallback = `${authEndpoint}?r=%target%&t=%jwt%`;
+            authUrlCallback = authUrlCallback.replace('%target%', encodeURIComponent(window.location.href));
+
             const url = new URL(apiBaseUrl);
             url.pathname = "/Session";
-            url.search = "?a=" + appToken;
-            url.search = url.search + "&r=%target%";
-            let jwtAuthUrl = url.toString();
+            url.search = `?a=${appToken}&r=${encodeURIComponent(authUrlCallback)}`;
+            let jwtUrl = url.toString();
 
-            var jwtUrl = jwtAuthUrl.replace("%target%", encodeURIComponent(window.location.href));
             window.location = jwtUrl;
+        } else {
+            restClient = new RESTClient(apiBaseUrl, authJwtToken, true);
         }
     }
 


### PR DESCRIPTION
* IDAS.authenticateWithJwt(): use auth callback URL (we want to redirect to client auth page fist, then to original page when finally authorized) - see Auth.svelte on draf PR: https://github.com/gandalan/svelte-idas-app/pull/1 
* re-create RESTClient correctly for JWT -> IDAS.authorizeWithJwt() to be used on client side

NOTE:
* I still need to make a change in IDAS.WebAPI to correctly respond for requests with "Authorization: Bearer xxx" header
* there is pending PR on IDAS for regarding JWT services: https://dev.azure.com/gandalan/IDAS/_git/IDAS/pullrequest/253 