### PR TITLE
Store JwtCallback path & authorizeWithJwt() as Promise

### DIFF
--- a/WebLibs/api/IDAS.js
+++ b/WebLibs/api/IDAS.js
@@ -38,23 +38,27 @@ export class IDAS {
     }
 
     async authenticateWithSSO(forceRenew = false) { 
-        if (!authToken)
-        {
-            const url = new URL(apiBaseUrl);
-            url.pathname = "/SSO";
-            url.search = "?a=" + appToken;
-            if (forceRenew)
-                url.search = url.search + "&forceRenew=true";
-            url.search = url.search + "&r=%target%%3Ft=%token%%26m=%mandant%";
-            let ssoAuthUrl = url.toString();
+        return new Promise((resolve, reject) => {
+            if (!authToken) {
+                const url = new URL(apiBaseUrl);
+                url.pathname = "/SSO";
+                url.search = "?a=" + appToken;
+                if (forceRenew)
+                    url.search = url.search + "&forceRenew=true";
+                url.search = url.search + "&r=%target%%3Ft=%token%%26m=%mandant%";
+                let ssoAuthUrl = url.toString();
 
-            var ssoURL = ssoAuthUrl.replace("%target%", encodeURIComponent(window.location.href));
-            window.location = ssoURL;
-        }
+                var ssoURL = ssoAuthUrl.replace("%target%", encodeURIComponent(window.location.href));
+                window.location = ssoURL;
+                reject('not authenticated yet');
+            } else {
+                resolve(restClient);
+            }
+        });
     }
 
     async authenticateWithJwt(authPath) {
-        var promise = new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (!authJwtToken) {
                 localStorage.setItem('IDAS_AuthJwtCallbackPath', authPath);
                 const authEndpoint = (new URL(window.location.href).origin) + authPath;
@@ -72,8 +76,7 @@ export class IDAS {
                 restClient = new RESTClient(apiBaseUrl, authJwtToken, true);
                 resolve(restClient);
             }    
-        })
-        return promise;
+        });
     }
 
     mandantGuid = localStorage.getItem('IDAS_MandantGuid');

--- a/WebLibs/api/IDAS.js
+++ b/WebLibs/api/IDAS.js
@@ -43,8 +43,10 @@ export class IDAS {
                 const url = new URL(apiBaseUrl);
                 url.pathname = "/SSO";
                 url.search = "?a=" + appToken;
-                if (forceRenew)
+                if (forceRenew) {
                     url.search = url.search + "&forceRenew=true";
+                }
+                    
                 url.search = url.search + "&r=%target%%3Ft=%token%%26m=%mandant%";
                 let ssoAuthUrl = url.toString();
 

--- a/WebLibs/package-lock.json
+++ b/WebLibs/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mdi/js": "^7.0.96",
         "axios": "^0.27.2",
+        "jwt-decode": "^3.1.2",
         "svelte-table": "^0.5.1"
       },
       "devDependencies": {
@@ -1739,6 +1740,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3830,6 +3836,11 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
       "peer": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "levn": {
       "version": "0.4.1",

--- a/WebLibs/package.json
+++ b/WebLibs/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@mdi/js": "^7.0.96",
     "axios": "^0.27.2",
+    "jwt-decode": "^3.1.2",
     "svelte-table": "^0.5.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Changes in this branch:
* no SSO support (only JWT) (breaking change)
* IDASFactory.create() (no "new IDAS()" calls) (breaking change)
* JWT with "refresh tokens" are now supported
* "refresh tokens" support is now moved into RESTClient.js
* depends on backend changes in https://dev.azure.com/gandalan/IDAS/_git/IDAS/pullrequest/253