### PR TITLE
Allow IDASFactory settings override with only partial settings

### DIFF
--- a/WebLibs/api/IDAS.js
+++ b/WebLibs/api/IDAS.js
@@ -1,16 +1,18 @@
 import { jwtTokenInvalid } from "./authUtils";
 import { RESTClient } from "./RESTClient";
 
-export function IDASFactory(settings = {
-        appToken : localStorage.getItem("IDAS_AppToken"),
-        mandantGuid : localStorage.getItem("IDAS_MandantGuid"),
-        apiBaseurl : localStorage.getItem("IDAS_ApiBaseUrl"),
-        jwtRefreshToken : localStorage.getItem("IDAS_AuthJwtRefreshToken"),
-        jwtCallbackPath : localStorage.getItem("IDAS_AuthJwtCallbackPath")
-      }) 
+export function IDASFactory(settings)
 {
+    let defaultSettings = {
+        appToken: localStorage.getItem("IDAS_AppToken"),
+        mandantGuid: localStorage.getItem("IDAS_MandantGuid"),
+        apiBaseurl: localStorage.getItem("IDAS_ApiBaseUrl"),
+        jwtRefreshToken: localStorage.getItem("IDAS_AuthJwtRefreshToken"),
+        jwtCallbackPath: localStorage.getItem("IDAS_AuthJwtCallbackPath"),
+    };
+    settings = Object.assign({}, defaultSettings, settings)
     let idas = undefined;
-    if (!jwtTokenInvalid(settings)) 
+    if (!jwtTokenInvalid(settings))
     { 
         console.log("init: with JWT token");
         idas = new IDAS(settings);

--- a/WebLibs/api/IDAS.js
+++ b/WebLibs/api/IDAS.js
@@ -10,7 +10,7 @@ export function IDASFactory(settings)
         jwtRefreshToken: localStorage.getItem("IDAS_AuthJwtRefreshToken"),
         jwtCallbackPath: localStorage.getItem("IDAS_AuthJwtCallbackPath"),
     };
-    settings = Object.assign({}, defaultSettings, settings)
+    settings = { ...defaultSettings, ...settings };
     let idas = undefined;
     if (!jwtTokenInvalid(settings))
     { 


### PR DESCRIPTION
With this change we can have only partial settings, without a need to pass all of them. 
Example
`let idas = IDASFactory({ apiBaseurl: "http://localhost/api" });`