### PR TITLE
Update NuGets. Fix `IDE1006` (naming rule violation)

### DIFF
--- a/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
@@ -20,7 +20,7 @@
     <None Remove="Assets\Neher\Logo.png" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="PropertyChanged.Fody" Version="4.0.5" PrivateAssets="All" />
+	<PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Gandalan.IDAS.WebApi.Client\Gandalan.IDAS.WebApi.Client.csproj" />

--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
@@ -140,7 +140,7 @@ namespace Gandalan.IDAS.WebApi.Client
                 Status = apiex.Message;
                 if (Status.ToLower().Contains("<title>"))
                 {
-                    Status = internalStripHtml(Status);
+                    Status = InternalStripHtml(Status);
                 }
 
                 if (apiex.InnerException != null)
@@ -205,7 +205,7 @@ namespace Gandalan.IDAS.WebApi.Client
                 Status = apiex.Message;
                 if (Status.ToLower().Contains("<title>"))
                 {
-                    Status = internalStripHtml(Status);
+                    Status = InternalStripHtml(Status);
                 }
 
                 if (apiex.InnerException != null)
@@ -653,7 +653,7 @@ namespace Gandalan.IDAS.WebApi.Client
             }
         }
 
-        private string internalStripHtml(string htmlString)
+        private static string InternalStripHtml(string htmlString)
         {
             var result = htmlString;
             if (result.ToLower().Contains("<title>") && result.ToLower().Contains("</title>"))
@@ -713,7 +713,7 @@ namespace Gandalan.IDAS.WebApi.Client
                 Status = apiex.Message;
                 if (Status.ToLower().Contains("<title>"))
                 {
-                    Status = internalStripHtml(Status);
+                    Status = InternalStripHtml(Status);
                 }
 
                 if (apiex.InnerException != null)
@@ -751,7 +751,7 @@ namespace Gandalan.IDAS.WebApi.Client
                 Status = apiex.Message;
                 if (Status.ToLower().Contains("<title>"))
                 {
-                    Status = internalStripHtml(Status);
+                    Status = InternalStripHtml(Status);
                 }
 
                 if (apiex.InnerException != null)

--- a/Gandalan.IDAS.WebApi.Client/GDL.IDAS.WebApi.Client.nuspec
+++ b/Gandalan.IDAS.WebApi.Client/GDL.IDAS.WebApi.Client.nuspec
@@ -12,8 +12,8 @@
         <license type="expression">MIT</license>
         <dependencies>
           <dependency id="GDL.IDAS.Logging" version="BUILDVERSION" />
-          <dependency id="Newtonsoft.Json" version="13.0.1" />
-          <dependency id="System.IdentityModel.Tokens.Jwt" version="6.23.1" />
+          <dependency id="Newtonsoft.Json" version="13.0.2" />
+          <dependency id="System.IdentityModel.Tokens.Jwt" version="6.25.1" />
         </dependencies>
     </metadata>
     <files>

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net5.0;net48;net472</TargetFrameworks>
@@ -20,9 +20,9 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="PropertyChanged.Fody" Version="4.0.5" PrivateAssets="All" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- NewtonSoft.Json: https://github.com/JamesNK/Newtonsoft.Json/releases/tag/13.0.2
- PropertyChanged.Fody: https://github.com/Fody/PropertyChanged/releases/tag/4.1.0
- System.IdentityModel.Tokens.Jwt: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases

This will also fix NuGet consolidate in Backend