### PR TITLE
Use standard exception print. Use LogConsoleDebug as public

### DIFF
--- a/Gandalan.IDAS.Logging/Logging/L.cs
+++ b/Gandalan.IDAS.Logging/Logging/L.cs
@@ -12,28 +12,12 @@ namespace Gandalan.IDAS.Logging
 
         public static void Fehler(Exception ex, string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{message} {ex.GetType().FullName}: {ex.Message}{Environment.NewLine}Stacktrace: {ex.StackTrace}", context, sender);
-
-            var innerException = ex.InnerException;
-            while (innerException != null)
-            {
-                Fehler(innerException, $"{message} InnerException", context, sender);
-
-                innerException = innerException.InnerException;
-            }
+            Fehler($"{message} {ex}", context, sender);
         }
 
         public static void Fehler(Exception ex, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{ex.GetType().FullName}: {ex.Message}{Environment.NewLine}Stacktrace: {ex.StackTrace}", context, sender);
-
-            var innerException = ex.InnerException;
-            while (innerException != null)
-            {
-                Fehler(innerException, "InnerException", context, sender);
-
-                innerException = innerException.InnerException;
-            }
+            Fehler($"{ex}", context, sender);
         }
 
         public static void Immer(string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)

--- a/Gandalan.IDAS.Logging/Logging/Logger.cs
+++ b/Gandalan.IDAS.Logging/Logging/Logger.cs
@@ -99,7 +99,11 @@ namespace Gandalan.IDAS.Logging
             LogConsoleDebug(log);
         }
 
-        private static void LogConsoleDebug(string message)
+        /// <summary>
+        /// Write to Console and Debug output. Does not write anything to file.
+        /// </summary>
+        /// <param name="message">Message to print</param>
+        public static void LogConsoleDebug(string message)
         {
             Debug.WriteLine(message);
             Console.WriteLine(message);

--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Net;
+﻿using Gandalan.IDAS.Logging;
+using Newtonsoft.Json;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Gandalan.IDAS.WebApi.Client.Settings
 {
@@ -12,10 +12,10 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
 
         public async Task<HubResponse> GetEndpoints(string apiVersion = null, string env = null, string clientOS = null)
         {
-            var requestURL = 
+            var requestURL =
                 _hubURL + "?" +
-                (apiVersion != null ? "apiVersion=" + apiVersion + "&" : "") + 
-                (env != null ? "env=" + env + "&" : "") + 
+                (apiVersion != null ? "apiVersion=" + apiVersion + "&" : "") +
+                (env != null ? "env=" + env + "&" : "") +
                 (clientOS != null ? "clientOS=" + clientOS : "");
             try
             {
@@ -24,7 +24,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Logger.LogConsoleDebug($"{e}");
                 throw;
             }
         }

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
@@ -1,9 +1,9 @@
-﻿using Gandalan.IDAS.Client.Contracts.Contracts;
+using Gandalan.IDAS.Client.Contracts.Contracts;
+using Gandalan.IDAS.Logging;
 using Gandalan.IDAS.WebApi.DTO;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -39,6 +39,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             {
                 return _settings[name];
             }
+
             return null;
         }
 
@@ -94,9 +95,10 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                             _settings.Add(friendlyName, localEnvironment);
                             internalLoadSavedAuthToken(friendlyName, localEnvironment);
                         }
-                    } catch (Exception ex)
+                    }
+                    catch (Exception ex)
                     {
-                        Debug.WriteLine($"Loading local env {friendlyName}: {ex.Message}");
+                        Logger.LogConsoleDebug($"Loading local env {friendlyName}: {ex}");
                     }
                 }
             }
@@ -160,6 +162,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                     // damaged file, ignore saved token
                 }
             }
+
             return null;
         }
 


### PR DESCRIPTION
Extended exception (single) from `TestController` before:

```
Allgemein       Fehler   19:14:19 .ctor           ExtendedStatusCodeResult: Status: BadRequest System.NullReferenceException: Test NRE exception - should be inside ExtendedStatusCodeResult
Stacktrace:    at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 43
```

After:

```
Allgemein       Fehler   19:15:37 .ctor           ExtendedStatusCodeResult: Status: BadRequest System.NullReferenceException: Test NRE exception - should be inside ExtendedStatusCodeResult
   at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 43
```

Extended Inner exception from `TestController` before:

```
Allgemein       Fehler   19:14:50 .ctor           ExtendedStatusCodeResult: Status: BadRequest System.NullReferenceException: Test NRE exception with inner exception - should be inside ExtendedStatusCodeResult
Stacktrace:    at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 59
Allgemein       Fehler   19:14:50 .ctor           ExtendedStatusCodeResult: Status: BadRequest InnerException System.DivideByZeroException: DivideByZeroException as Inner Exception
Stacktrace:    at Gandalan.IDAS.WebApi.Controllers.TestController.ThrowInnerException() in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 78
   at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 54
```

After (**NOTE: This is now one log entry**):

```
Allgemein       Fehler   19:16:37 .ctor           ExtendedStatusCodeResult: Status: BadRequest System.NullReferenceException: Test NRE exception with inner exception - should be inside ExtendedStatusCodeResult ---> System.DivideByZeroException: DivideByZeroException as Inner Exception
   at Gandalan.IDAS.WebApi.Controllers.TestController.ThrowInnerException() in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 78
   at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 54
   --- End of inner exception stack trace ---
   at Gandalan.IDAS.WebApi.Controllers.TestController.TestException(ExceptionType exceptionType) in C:\Gandalan\IDAS\Source\IDASWebApi\Gandalan.IDAS.WebApi.Common\Controllers\TestController.cs:line 59
```