### PR TITLE
Use StreamContent() instead of ByteArrayContent()

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/MailWebRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/MailWebRoutinen.cs
@@ -24,12 +24,9 @@ namespace Gandalan.IDAS.WebApi.Client.BusinessRoutinen
                 foreach (var attachment in attachments)
                 {
                     // read each file and add it to the multipart form data
-                    var fileContent = new ByteArrayContent(File.ReadAllBytes(attachment));
-                    fileContent.Headers.ContentDisposition = new System.Net.Http.Headers.ContentDispositionHeaderValue("attachment")
-                    {
-                        FileName = Path.GetFileName(attachment)
-                    };
-                    content.Add(fileContent, "files", Path.GetFileName(attachment));
+                    var fileStream = File.OpenRead(attachment);
+                    var fileContentStream = new StreamContent(fileStream);
+                    content.Add(fileContentStream, "files", Path.GetFileName(attachment));
                 }
             }
             await PostDataAsync("Mail", content, version : "2.0");


### PR DESCRIPTION
Use StreamContent() instead of ByteArrayContent() for form files to allow WebApi support on both .NETFramework and .Net Core WebApi

Tested new changes on IDAS.Backend.WebApi (master) and it requires no change.
Additional changes are required on GAN-94 branch (with EFCore)