### PR TITLE
#10365 Fix warnings. Addendum to 5287ddf

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/DTOs/Belege/BelegDruckDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Belege/BelegDruckDTO.cs
@@ -1,5 +1,4 @@
 using Gandalan.IDAS.WebApi.Client.DTOs.Allgemein;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -39,8 +38,10 @@ namespace Gandalan.IDAS.WebApi.DTO
                 Ansprechpartner = ""; //??? _apiSettings?.AuthToken?.Benutzer?.Vorname + " " + _apiSettings?.AuthToken?.Benutzer?.Nachname;
                 Telefonnummer = ""; //??? _apiSettings?.AuthToken?.Benutzer?.TelefonNummer ?? "";
 
-                if (vorgang.ApplicationSpecificProperties != null && vorgang.ApplicationSpecificProperties.Count != 0 && vorgang.ApplicationSpecificProperties.ContainsKey("settings") && vorgang.ApplicationSpecificProperties["settings"].ContainsKey("Kontrollkuerzel"))
-                    Kontrollkuerzel = vorgang.ApplicationSpecificProperties["settings"]["Kontrollkuerzel"] as string;
+                if (vorgang.ApplicationSpecificProperties != null && vorgang.ApplicationSpecificProperties.Count != 0 && vorgang.ApplicationSpecificProperties.TryGetValue("settings", out var settings) && settings.TryGetValue("Kontrollkuerzel", out var kontrollkuerzel))
+                {
+                    Kontrollkuerzel = kontrollkuerzel as string;
+                }
 
                 var abBelege = vorgang.Belege.Where(b => b.BelegArt == "AB" || b.BelegArt == "Auftragsbestätigung");
                 Bestelldatum = abBelege.Any() ? abBelege.Last().BelegDatum.ToString("d", culture) : "";


### PR DESCRIPTION
Use TryGetValue instead of ContainsKey to avoid double lookup

FYI: @gdl-gruendig 