### PR TITLE
Print DetailedException in logs + new line before exception

### DIFF
--- a/Gandalan.IDAS.Logging/Logging/L.cs
+++ b/Gandalan.IDAS.Logging/Logging/L.cs
@@ -12,12 +12,12 @@ namespace Gandalan.IDAS.Logging
 
         public static void Fehler(Exception ex, string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{message}{Environment.NewLine}{DetailedStringException(ex)}", context, sender);
+            Fehler($"{message}{Environment.NewLine}{DetailedException(ex)}", context, sender);
         }
 
         public static void Fehler(Exception ex, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{DetailedStringException(ex)}", context, sender);
+            Fehler($"{DetailedException(ex)}", context, sender);
         }
 
         public static void Immer(string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
@@ -45,7 +45,7 @@ namespace Gandalan.IDAS.Logging
         /// </summary>
         /// <param name="ex">Exception</param>
         /// <returns>String with Data and exception</returns>
-        private static string DetailedStringException(Exception ex)
+        private static string DetailedException(Exception ex)
         {
             // Use default exception formatting
             var exString = $"{ex}";

--- a/Gandalan.IDAS.Logging/Logging/L.cs
+++ b/Gandalan.IDAS.Logging/Logging/L.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Gandalan.IDAS.Logging
@@ -12,12 +12,12 @@ namespace Gandalan.IDAS.Logging
 
         public static void Fehler(Exception ex, string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{message} {ex}", context, sender);
+            Fehler($"{message}{Environment.NewLine}{DetailedStringException(ex)}", context, sender);
         }
 
         public static void Fehler(Exception ex, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
-            Fehler($"{ex}", context, sender);
+            Fehler($"{DetailedStringException(ex)}", context, sender);
         }
 
         public static void Immer(string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
@@ -38,6 +38,30 @@ namespace Gandalan.IDAS.Logging
         public static void Diagnose(string message, LogContext context = LogContext.Allgemein, [CallerMemberName] string sender = null)
         {
             Logger.GetInstance().Log(message, LogLevel.Diagnose, context, sender);
+        }
+
+        /// <summary>
+        /// Return string with detailed exception - data from RESTRoutinen.AddInfoToException.
+        /// </summary>
+        /// <param name="ex">Exception</param>
+        /// <returns>String with Data and exception</returns>
+        private static string DetailedStringException(Exception ex)
+        {
+            // Use default exception formatting
+            var exString = $"{ex}";
+            if (ex.Data.Contains("URL") && ex.Data.Contains("CallMethod") && ex.Data.Contains("StatusCode"))
+            {
+                var newLine = Environment.NewLine;
+                object response = null;
+                if (ex.Data.Contains("Response"))
+                {
+                    response = $"{newLine}Response: {ex.Data["Response"]}";
+                }
+
+                exString = $"URL: {ex.Data["URL"]}{newLine}CallMethod: {ex.Data["CallMethod"]}{newLine}StatusCode: {ex.Data["StatusCode"]}{response}{newLine}{ex}";
+            }
+
+            return exString;
         }
     }
 }


### PR DESCRIPTION
Example:

```
Allgemein       Fehler   15:08:22 GetItem         produktGruppenStore exception after retrieveDataIfCacheMiss (Func target: 'Gandalan.Client.Common.Flux.ProduktgruppenStore') (Time: 600,915 seconds)
URL: ProduktGruppe?includeFamilien=True&includeVarianten=True&includeUIDefs=True&maxLevel=99
CallMethod: MoveNext
StatusCode: InternalServerError
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   (StackTrace)
```