### PR TITLE
`TreatWarningsAsErrors` for all build configurations

### DIFF
--- a/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
+++ b/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
@@ -10,13 +10,12 @@
     <FileVersion Condition=" '$(BUILDNUMBER)' != '' ">$(BUILDNUMBER)</FileVersion>
     <Version>2099.0.0-alpha</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.Contracts\GDL.IDAS.Contracts.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -34,5 +33,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Gandalan.IDAS.WebApi.Client\Gandalan.IDAS.WebApi.Client.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
+++ b/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.Contracts\GDL.IDAS.Contracts.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
+++ b/Gandalan.IDAS.Contracts/Gandalan.IDAS.Contracts.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.Contracts\GDL.IDAS.Contracts.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
+++ b/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Crypto\GDL.IDAS.Crypto.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
+++ b/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Crypto\GDL.IDAS.Crypto.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
+++ b/Gandalan.IDAS.Crypto/Gandalan.IDAS.Crypto.csproj
@@ -10,13 +10,12 @@
     <FileVersion Condition=" '$(BUILDNUMBER)' != '' ">$(BUILDNUMBER)</FileVersion>
     <Version>2099.0.0-alpha</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Crypto\GDL.IDAS.Crypto.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
+++ b/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
@@ -10,13 +10,12 @@
     <FileVersion Condition=" '$(BUILDNUMBER)' != '' ">$(BUILDNUMBER)</FileVersion>
     <Version>2099.0.0-alpha</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Logging\GDL.IDAS.Logging.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
+++ b/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Logging\GDL.IDAS.Logging.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
+++ b/Gandalan.IDAS.Logging/Gandalan.IDAS.Logging.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.Logging\GDL.IDAS.Logging.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.WebApi.Client.Wpf\GDL.IDAS.WebApi.Client.Wpf.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\Icons\view-1.png" />

--- a/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.WebApi.Client.Wpf\GDL.IDAS.WebApi.Client.Wpf.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Assets\Icons\view-1.png" />

--- a/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
+++ b/Gandalan.IDAS.WebApi.Client.Wpf/Gandalan.IDAS.WebApi.Client.Wpf.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
     <UseWPF>true</UseWPF>
@@ -10,33 +11,39 @@
     <FileVersion Condition=" '$(BUILDNUMBER)' != '' ">$(BUILDNUMBER)</FileVersion>
     <Version>2099.0.0-alpha</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Projects\idas-client-libs\Gandalan.IDAS.WebApi.Client.Wpf\GDL.IDAS.WebApi.Client.Wpf.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Assets\Icons\view-1.png" />
     <None Remove="Assets\Icons\view-off.png" />
     <None Remove="Assets\Neher\Logo.png" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="..\README.md" Link="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
   <ItemGroup>
-	<PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Gandalan.IDAS.WebApi.Client\Gandalan.IDAS.WebApi.Client.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
+
   <ItemGroup>
     <Resource Include="Assets\Icons\view-1.png" />
     <Resource Include="Assets\Icons\view-off.png" />

--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/NotifyWebRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/NotifyWebRoutinen.cs
@@ -1,14 +1,14 @@
+using Gandalan.IDAS.Client.Contracts.Contracts;
+using Gandalan.IDAS.WebApi.Client.DTOs.Nachrichten;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Gandalan.IDAS.Client.Contracts.Contracts;
-using Gandalan.IDAS.WebApi.Client.DTOs.Nachrichten;
 
 namespace Gandalan.IDAS.WebApi.Client.BusinessRoutinen
 {
     public class NotifyWebRoutinen : WebRoutinenBase
     {
-        private readonly bool _validConfig = false;
+        private readonly bool _validConfig;
 
         public NotifyWebRoutinen(IWebApiConfig settings) : base(settings)
         {
@@ -24,7 +24,7 @@ namespace Gandalan.IDAS.WebApi.Client.BusinessRoutinen
         public async Task<IList<NachrichtenDTO>> GetAllNotificationsAsync()
         {
             if (!_validConfig)
-                return new List<NachrichtenDTO>();    
+                return new List<NachrichtenDTO>();
             var mandant = Settings.AuthToken.Mandant.MandantGuid;
             var produzent = Settings.AuthToken.Mandant.ProduzentMandantGuid;
             return await GetAsync<List<NachrichtenDTO>>($"Nachrichten?mandantGuid={mandant}&produzentGuid={produzent}");

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.WebApi.Client\GDL.IDAS.WebApi.Client.xml</DocumentationFile>
     <NoWarn>1591;CS0067</NoWarn>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.WebApi.Client\GDL.IDAS.WebApi.Client.xml</DocumentationFile>
     <NoWarn>1591;CS0067</NoWarn>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.1|AnyCPU'">

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -10,13 +10,12 @@
     <FileVersion Condition=" '$(BUILDNUMBER)' != '' ">$(BUILDNUMBER)</FileVersion>
     <Version>2099.0.0-alpha</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\projects\Repos\idas-client-libs\Gandalan.IDAS.WebApi.Client\GDL.IDAS.WebApi.Client.xml</DocumentationFile>
     <NoWarn>1591;CS0067</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -42,5 +41,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Gandalan.IDAS.Logging\Gandalan.IDAS.Logging.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This same as https://github.com/gandalan/idas-client-libs/pull/297, but for C#

Fixed warning introduced in 3c196878d04124b00b4b0fb239a2f6e0dcb397a3