### PR TITLE
Enable `dotnet_sort_system_directives_first`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 ### From: https://github.com/dotnet/aspnetcore/blob/main/.editorconfig
 ### Last sync: b3d1545
-### Disabled: dotnet_sort_system_directives_first, CA1018, CA1305, CA1510, CA2007, CA2208, IDE0011, IDE0073, IDE0161
+### Disabled: CA1018, CA1305, CA1510, CA2007, CA2208, IDE0011, IDE0073, IDE0161
 ; EditorConfig to support per-solution formatting.
 ; Use the EditorConfig VS add-in to make this work.
 ; http://editorconfig.org/
@@ -24,7 +24,7 @@ insert_final_newline = true
 
 [*.cs]
 indent_size = 4
-#dotnet_sort_system_directives_first = true
+dotnet_sort_system_directives_first = true
 
 # Don't use this. qualifier
 dotnet_style_qualification_for_field = false:suggestion


### PR DESCRIPTION
Now we should have consistent sorting for all developers