### PR TITLE
Fix for disappearing threads when calling `WebApiConfigurations.Initi…

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -25,9 +25,8 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                 (clientOs != null ? "clientOS=" + clientOs : "");
             try
             {
-                using var httpClient = new HttpClient();
-                var response = httpClient.GetStringAsync(requestUrl).GetAwaiter().GetResult();
-                return await Task.FromResult(JsonConvert.DeserializeObject<HubResponse>(response));
+                var response = await new HttpClient().GetStringAsync(requestUrl);
+                return JsonConvert.DeserializeObject<HubResponse>(response);
             }
             catch (Exception e)
             {

--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -10,7 +10,13 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
     {
         private const string HubUrl = "https://connect.idas-cloudservices.net/api/EndPoints";
 
+        [Obsolete("Call to GetEndpointsAsync")]
         public async Task<HubResponse> GetEndpoints(string apiVersion = null, string env = null, string clientOs = null)
+        {
+            return await GetEndpointsAsync(apiVersion, env, clientOs);
+        }
+
+        public async Task<HubResponse> GetEndpointsAsync(string apiVersion = null, string env = null, string clientOs = null)
         {
             var requestUrl =
                 HubUrl + "?" +

--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -10,7 +10,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
     {
         private const string HubUrl = "https://connect.idas-cloudservices.net/api/EndPoints";
 
-        [Obsolete("Call to GetEndpointsAsync")]
+        [Obsolete("Call GetEndpointsAsync")]
         public async Task<HubResponse> GetEndpoints(string apiVersion = null, string env = null, string clientOs = null)
         {
             return await GetEndpointsAsync(apiVersion, env, clientOs);

--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -31,7 +31,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             }
             catch (Exception e)
             {
-                L.Fehler(e, $"Fehler for GetEndpoints. Env: '{env}'");
+                L.Fehler(e, $"Exception for GetEndpoints. Env: '{env}'");
                 throw;
             }
         }

--- a/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/ConnectHub.cs
@@ -19,12 +19,13 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
                 (clientOs != null ? "clientOS=" + clientOs : "");
             try
             {
-                var response = await new HttpClient().GetStringAsync(requestUrl);
-                return JsonConvert.DeserializeObject<HubResponse>(response);
+                using var httpClient = new HttpClient();
+                var response = httpClient.GetStringAsync(requestUrl).GetAwaiter().GetResult();
+                return await Task.FromResult(JsonConvert.DeserializeObject<HubResponse>(response));
             }
             catch (Exception e)
             {
-                Logger.LogConsoleDebug($"{e}");
+                L.Fehler(e, $"Fehler for GetEndpoints. Env: '{env}'");
                 throw;
             }
         }

--- a/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
@@ -17,7 +17,6 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             throw new NotSupportedException("JWT:string parameter missing");
         }
 
-        [Obsolete("JWT:string parameter missing. Call InitializeAsync(Guid appToken, string env, string jwt)")]
         public override Task InitializeAsync(Guid appToken, string env)
         {
             throw new NotSupportedException("JWT:string parameter missing");

--- a/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
@@ -11,14 +11,20 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
     {
         public string JwtToken { get; set; }
 
-        public override Task Initialize(Guid appToken, string env)
+        public override Task InitializeAsync(Guid appToken, string env)
         {
             throw new NotSupportedException("JWT:string parameter missing");
         }
 
+        [Obsolete("Call InitializeAsync")]
         public async Task Initialize(Guid appToken, string env, string jwt)
         {
-            await base.Initialize(appToken, env);
+            await InitializeAsync(appToken, env, jwt);
+        }
+
+        public async Task InitializeAsync(Guid appToken, string env, string jwt)
+        {
+            await base.InitializeAsync(appToken, env);
             var tokenHandler = new JwtSecurityTokenHandler();
 
             if (!tokenHandler.CanReadToken(jwt))

--- a/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/JwtWebApiSettings.cs
@@ -11,6 +11,13 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
     {
         public string JwtToken { get; set; }
 
+        [Obsolete("JWT:string parameter missing. Call InitializeAsync(Guid appToken, string env, string jwt)")]
+        public override Task Initialize(Guid appToken, string env)
+        {
+            throw new NotSupportedException("JWT:string parameter missing");
+        }
+
+        [Obsolete("JWT:string parameter missing. Call InitializeAsync(Guid appToken, string env, string jwt)")]
         public override Task InitializeAsync(Guid appToken, string env)
         {
             throw new NotSupportedException("JWT:string parameter missing");

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
@@ -34,7 +34,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
         {
             if (!_isInitialized)
             {
-                throw new InvalidOperationException("WebApiConfigurations not initialized - call Initialize() first");
+                throw new InvalidOperationException("WebApiConfigurations not initialized - call WebApiConfigurations.Initialize() first");
             }
 
             if (_settings.TryGetValue(name, out var byName))
@@ -49,7 +49,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
         {
             if (!_isInitialized)
             {
-                throw new InvalidOperationException("WebApiConfigurations not initialized - call Initialize() first");
+                throw new InvalidOperationException("WebApiConfigurations not initialized - call WebApiConfigurations.Initialize() first");
             }
 
             return new List<IWebApiConfig>(_settings.Values);

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
@@ -18,13 +18,19 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
         private static string _appTokenString;
         private static bool _isInitialized;
 
+        [Obsolete("Call to InitializeAsync")]
         public static async Task Initialize(Guid appToken)
+        {
+            await InitializeAsync(appToken);
+        }
+
+        public static async Task InitializeAsync(Guid appToken)
         {
             _settings = new Dictionary<string, IWebApiConfig>(StringComparer.OrdinalIgnoreCase);
             _settingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Gandalan");
             _appTokenString = appToken.ToString().Trim('{', '}');
 
-            await SetupEnvironments(appToken);
+            await SetupEnvironmentsAsync(appToken);
             SetupLocalEnvironment(appToken);
 
             _isInitialized = true;
@@ -113,12 +119,12 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             }
         }
 
-        private static async Task SetupEnvironments(Guid appToken)
+        private static async Task SetupEnvironmentsAsync(Guid appToken)
         {
             var hub = new ConnectHub();
             foreach (var env in _environments)
             {
-                var response = await hub.GetEndpoints("2.1", env, "win");
+                var response = await hub.GetEndpointsAsync("2.1", env, "win");
                 IWebApiConfig environment = null;
                 if (response != null)
                 {

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiConfigurations.cs
@@ -18,7 +18,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
         private static string _appTokenString;
         private static bool _isInitialized;
 
-        [Obsolete("Call to InitializeAsync")]
+        [Obsolete("Call InitializeAsync")]
         public static async Task Initialize(Guid appToken)
         {
             await InitializeAsync(appToken);

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
@@ -92,7 +92,7 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
             catch (Exception e)
             {
                 // Non awaitable callers will not see exception thrown here, but we will always have logged exception
-                L.Fehler(e);
+                L.Fehler(e, $"Exception in InitializeAsync. Env: '{env}'");
                 throw;
             }
         }

--- a/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
+++ b/Gandalan.IDAS.WebApi.Client/Settings/WebApiSettings.cs
@@ -56,8 +56,17 @@ namespace Gandalan.IDAS.WebApi.Client.Settings
 
         /// <remarks>
         /// Remember to call <see cref="WebApiConfigurations.Initialize"/> before.
-        /// </remarks>>
+        /// </remarks>
+        [Obsolete("Call InitializeAsync")]
         public virtual async Task Initialize(Guid appToken, string env)
+        {
+            await InitializeAsync(appToken, env);
+        }
+
+        /// <remarks>
+        /// Remember to call <see cref="WebApiConfigurations.Initialize"/> before.
+        /// </remarks>
+        public virtual async Task InitializeAsync(Guid appToken, string env)
         {
             try
             {


### PR DESCRIPTION
…alize()` from constructor

More info: https://stackoverflow.com/questions/57999839/httpclient-getstringasync-is-not-executed

I also added `<remarks>` documentation and exception logging - previously we had nothing in IBOS2 Legacy logs