### PR TITLE
Add IAIService interface to handle external AI calls

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/Contracts/DataServices/IAIService.cs
+++ b/Gandalan.IDAS.WebApi.Client/Contracts/DataServices/IAIService.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Gandalan.Client.Contracts.DataServices;
+
+/// <summary>
+/// Interface for handling calls to an external AI service
+/// </summary>
+public interface IAIService
+{
+    /// <summary>
+    /// Sends a request to the AI service and returns the response
+    /// </summary>
+    /// <param name="input">The input string to send to the AI service</param>
+    /// <returns>The response from the AI service</returns>
+    Task<string> GetResponseAsync(string input);
+
+    /// <summary>
+    /// Trains the AI model with the provided training data
+    /// </summary>
+    /// <param name="trainingData">The training data to use for training the AI model</param>
+    Task TrainModelAsync(IEnumerable<string> trainingData);
+
+    /// <summary>
+    /// Saves the current AI model to the specified path
+    /// </summary>
+    /// <param name="modelPath">The path to save the AI model</param>
+    Task SaveModelAsync(string modelPath);
+
+    /// <summary>
+    /// Loads an AI model from the specified path
+    /// </summary>
+    /// <param name="modelPath">The path to load the AI model from</param>
+    Task LoadModelAsync(string modelPath);
+}


### PR DESCRIPTION
Add new `IAIService` interface to handle calls to an external AI service.

* Define `IAIService` interface with top-level namespace `Gandalan.Client.Contracts.DataServices`.
* Add method `Task<string> GetResponseAsync(string input);` to send a request to the AI service and return the response.
* Add method `Task TrainModelAsync(IEnumerable<string> trainingData);` to train the AI model with the provided training data.
* Add method `Task SaveModelAsync(string modelPath);` to save the current AI model to the specified path.
* Add method `Task LoadModelAsync(string modelPath);` to load an AI model from the specified path.

