### PR TITLE
#13627 Alle Farbgruppen an i3 ausspielen. 

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/DTOs/Farben/FarbGruppeDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Farben/FarbGruppeDTO.cs
@@ -14,6 +14,8 @@ public class FarbGruppeDTO
     public DateTime ChangedDate { get; set; }
     public int Reihenfolge { get; set; }
 
+    public bool IstGesperrt { get; set; }
+
     public IList<Guid> FarbItemGuids { get; set; }
     public IList<Guid> OberflaecheGuids { get; set; }
 


### PR DESCRIPTION
gesperrte Farbgruppen werden vom Backend mit dem Flag IstGespert gekennzeichnet.