### PR TITLE
15146 fix concurrent httpclient races

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
@@ -14,6 +14,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Gandalan.IDAS.Client.Contracts.Contracts;
@@ -36,8 +37,7 @@ public class WebRoutinenBase
     public IWebApiConfig Settings;
     private readonly IWebApiConfig _originalSettings;
     public bool IsJwt;
-    private volatile RESTRoutinen _restRoutinen;
-    private readonly object _restRoutineInitLock = new object();
+    private readonly Lazy<RESTRoutinen> _restRoutinen;
     private const string RelativeDateTimePattern = @"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2})";
 
     #endregion
@@ -86,20 +86,13 @@ public class WebRoutinenBase
                 AuthToken = settings.AuthToken;
             }
         }
+
+        _restRoutinen = new Lazy<RESTRoutinen>(InitRestRoutinen, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    private async Task runPreRequestChecks(string url, bool skipAuth = false, [CallerMemberName] string sender = null)
+    private async Task RunPreRequestChecks(string url, bool skipAuth = false, [CallerMemberName] string sender = null)
     {
-        if (_restRoutinen == null)
-        {
-            lock (_restRoutineInitLock)
-            {
-                if (_restRoutinen == null)
-                {
-                    initRestRoutinen();
-                }
-            }
-        }
+        _ = _restRoutinen.Value;
 
         ThrowIfRateLimited(Settings.Url, sender);
         await CheckAuthorizedOrThrow(url, skipAuth, sender);
@@ -139,7 +132,7 @@ public class WebRoutinenBase
         }
     }
 
-    private void initRestRoutinen()
+    private RESTRoutinen InitRestRoutinen()
     {
         if (string.IsNullOrWhiteSpace(Settings.Url))
         {
@@ -164,8 +157,9 @@ public class WebRoutinenBase
 
         config.NewApiOptInUrls = Settings.NewApiOptInUrls;
 
-        _restRoutinen = new RESTRoutinen(config);
-        _restRoutinen.UpdatePerRequestHeaders(BuildAuthHeaders());
+        var restRoutinen = new RESTRoutinen(config);
+        restRoutinen.UpdatePerRequestHeaders(BuildAuthHeaders());
+        return restRoutinen;
     }
 
     private Dictionary<string, string> BuildAuthHeaders()
@@ -182,9 +176,10 @@ public class WebRoutinenBase
         return headers.Count > 0 ? headers : null;
     }
 
-    private void updateAuthInRestRoutinen()
+    private void UpdateAuthInRestRoutinen()
     {
-        _restRoutinen?.UpdatePerRequestHeaders(BuildAuthHeaders());
+        if (_restRoutinen.IsValueCreated)
+            _restRoutinen.Value.UpdatePerRequestHeaders(BuildAuthHeaders());
     }
 
     /// <summary>
@@ -194,7 +189,7 @@ public class WebRoutinenBase
     /// </summary>
     public void UpdateAuthHeaders()
     {
-        updateAuthInRestRoutinen();
+        UpdateAuthInRestRoutinen();
     }
 
     protected virtual void OnErrorOccured(ApiErrorArgs e)
@@ -212,7 +207,7 @@ public class WebRoutinenBase
     {
         if (IsJwt)
         {
-            return await checkJwtTokenAsync();
+            return await CheckJwtTokenAsync();
         }
 
         try
@@ -248,7 +243,7 @@ public class WebRoutinenBase
             {
                 AuthToken = result;
                 _originalSettings.AuthToken = result;
-                updateAuthInRestRoutinen();
+                UpdateAuthInRestRoutinen();
                 Status = "OK";
                 return true;
             }
@@ -263,7 +258,7 @@ public class WebRoutinenBase
             Status = apiEx.Message;
             if (Status.ToLower().Contains("<title>"))
             {
-                Status = internalStripHtml(Status);
+                Status = InternalStripHtml(Status);
             }
 
             var innerException = apiEx.InnerException;
@@ -299,7 +294,7 @@ public class WebRoutinenBase
             {
                 AuthToken = result;
                 _originalSettings.AuthToken = result;
-                updateAuthInRestRoutinen();
+                UpdateAuthInRestRoutinen();
             }
             return result;
         }
@@ -313,8 +308,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PostAsync<T>(uri, data, settings, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PostAsync<T>(uri, data, settings, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -333,8 +328,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            await _restRoutinen.PostAsync(uri, data, settings, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            await _restRoutinen.Value.PostAsync(uri, data, settings, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -351,8 +346,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PostDataAsync(uri, data, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PostDataAsync(uri, data, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -371,8 +366,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PostDataAsync(uri, data, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PostDataAsync(uri, data, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -391,8 +386,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.GetDataAsync(uri, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.GetDataAsync(uri, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -411,8 +406,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.GetAsync(uri, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.GetAsync(uri, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -431,8 +426,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.GetAsync<T>(uri, settings, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.GetAsync<T>(uri, settings, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -451,8 +446,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            await _restRoutinen.PutAsync(uri, data, settings, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            await _restRoutinen.Value.PutAsync(uri, data, settings, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -469,8 +464,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PutAsync<T>(uri, data, settings, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PutAsync<T>(uri, data, settings, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -489,8 +484,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PutDataAsync(uri, data);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PutDataAsync(uri, data);
         }
         catch (HttpRequestException ex)
         {
@@ -504,8 +499,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.PutDataAsync(uri, data);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.PutDataAsync(uri, data);
         }
         catch (HttpRequestException ex)
         {
@@ -524,8 +519,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            await _restRoutinen.DeleteAsync(uri);
+            await RunPreRequestChecks(uri, skipAuth);
+            await _restRoutinen.Value.DeleteAsync(uri);
         }
         catch (HttpRequestException ex)
         {
@@ -542,8 +537,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            await _restRoutinen.DeleteAsync(uri, data, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            await _restRoutinen.Value.DeleteAsync(uri, data, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -560,8 +555,8 @@ public class WebRoutinenBase
     {
         try
         {
-            await runPreRequestChecks(uri, skipAuth);
-            return await _restRoutinen.DeleteAsync<T>(uri, data, version: version);
+            await RunPreRequestChecks(uri, skipAuth);
+            return await _restRoutinen.Value.DeleteAsync<T>(uri, data, version: version);
         }
         catch (HttpRequestException ex)
         {
@@ -576,7 +571,7 @@ public class WebRoutinenBase
         return default;
     }
 
-    private static string internalStripHtml(string htmlString)
+    private static string InternalStripHtml(string htmlString)
     {
         var result = htmlString;
         if (result.ToLower().Contains("<title>") && result.ToLower().Contains("</title>"))
@@ -592,7 +587,7 @@ public class WebRoutinenBase
         return result;
     }
 
-    private async Task<bool> checkJwtTokenAsync()
+    private async Task<bool> CheckJwtTokenAsync()
     {
         if (internalCheckJwtToken(out var refreshToken, out var checkResult))
         {
@@ -617,7 +612,7 @@ public class WebRoutinenBase
                 jc.JwtToken = newJwt;
             }
             JwtToken = newJwt;
-            updateAuthInRestRoutinen();
+            UpdateAuthInRestRoutinen();
             return true;
         }
         catch (ApiException apiEx)
@@ -626,7 +621,7 @@ public class WebRoutinenBase
             Status = apiEx.Message;
             if (Status.ToLower().Contains("<title>"))
             {
-                Status = internalStripHtml(Status);
+                Status = InternalStripHtml(Status);
             }
 
             var innerException = apiEx.InnerException;
@@ -813,8 +808,8 @@ public class WebRoutinenBase
         {
             if (problemDetails.Status == 429)
             {
-                var resetDateTimeUtc = problemDetails.TryGetResetDateTimeUtc(out var resetTime) 
-                    ? resetTime 
+                var resetDateTimeUtc = problemDetails.TryGetResetDateTimeUtc(out var resetTime)
+                    ? resetTime
                     : DateTime.UtcNow.AddMinutes(1);
                 var rateLimitEx = new RateLimitException(resetDateTimeUtc, ex);
                 return new ApiException(problemDetails.Detail ?? problemDetails.Title, code, rateLimitEx, problemDetails, payload);

--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
@@ -751,10 +751,10 @@ public class WebRoutinenBase
             OnErrorOccured(new ApiErrorArgs(exception.Message, exception.StatusCode));
         }
 
-        var foundUrlInData = false;
+        var foundUrlInData = exception.Data.Contains("URL");
 
-        // Check if we already have data from RESTRoutinen.AddInfoToException()
-        if (!exception.Data.Contains("URL"))
+        // Check if ErrorEnrichmentHandler already enriched an inner exception with URL/StatusCode/Response
+        if (!foundUrlInData)
         {
             var innerException = exception.InnerException;
             while (innerException != null)
@@ -762,22 +762,24 @@ public class WebRoutinenBase
                 if (innerException.Data.Contains("URL"))
                 {
                     foundUrlInData = true;
+                    break;
                 }
 
                 innerException = innerException.InnerException;
             }
         }
-        else
-        {
-            foundUrlInData = true;
-        }
 
         if (!foundUrlInData)
         {
             exception.Data.Add("URL", new Uri(new Uri(Settings.Url), url).ToString());
-            exception.Data.Add("CallMethod", sender);
             exception.Data.Add("StatusCode", exception.StatusCode);
             exception.Data.Add("Payload", exception.Payload);
+        }
+
+        // Always add CallMethod so the calling WebRoutinen method is traceable
+        if (!exception.Data.Contains("CallMethod"))
+        {
+            exception.Data.Add("CallMethod", sender);
         }
 
         // Add data from ProblemDetails if available

--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs
@@ -7,6 +7,7 @@
 // *****************************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
@@ -35,7 +36,8 @@ public class WebRoutinenBase
     public IWebApiConfig Settings;
     private readonly IWebApiConfig _originalSettings;
     public bool IsJwt;
-    private RESTRoutinen _restRoutinen;
+    private volatile RESTRoutinen _restRoutinen;
+    private readonly object _restRoutineInitLock = new object();
     private const string RelativeDateTimePattern = @"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2})";
 
     #endregion
@@ -90,7 +92,13 @@ public class WebRoutinenBase
     {
         if (_restRoutinen == null)
         {
-            initRestRoutinen();
+            lock (_restRoutineInitLock)
+            {
+                if (_restRoutinen == null)
+                {
+                    initRestRoutinen();
+                }
+            }
         }
 
         ThrowIfRateLimited(Settings.Url, sender);
@@ -145,15 +153,10 @@ public class WebRoutinenBase
             UserAgent = Settings.UserAgent
         };
 
-        if (IsJwt && !string.IsNullOrEmpty(JwtToken))
-        {
-            config.AdditionalHeaders.Add("Authorization", $"Bearer {JwtToken}");
-        }
-        else if (AuthToken != null)
-        {
-            config.AdditionalHeaders.Add("X-Gdl-AuthToken", AuthToken.Token.ToString());
-        }
-
+        // InstallationId is stable and can remain in DefaultRequestHeaders.
+        // Auth headers (token / JWT) are intentionally excluded here: they are
+        // injected per-request via UpdatePerRequestHeaders so that token refreshes
+        // never cause a new HttpClient to be created in the static factory cache.
         if (Settings.InstallationId != Guid.Empty)
         {
             config.AdditionalHeaders.Add("X-Gdl-InstallationId", Settings.InstallationId.ToString());
@@ -162,6 +165,36 @@ public class WebRoutinenBase
         config.NewApiOptInUrls = Settings.NewApiOptInUrls;
 
         _restRoutinen = new RESTRoutinen(config);
+        _restRoutinen.UpdatePerRequestHeaders(BuildAuthHeaders());
+    }
+
+    private Dictionary<string, string> BuildAuthHeaders()
+    {
+        var headers = new Dictionary<string, string>();
+        if (IsJwt && !string.IsNullOrEmpty(JwtToken))
+        {
+            headers["Authorization"] = $"Bearer {JwtToken}";
+        }
+        else if (AuthToken != null)
+        {
+            headers["X-Gdl-AuthToken"] = AuthToken.Token.ToString();
+        }
+        return headers.Count > 0 ? headers : null;
+    }
+
+    private void updateAuthInRestRoutinen()
+    {
+        _restRoutinen?.UpdatePerRequestHeaders(BuildAuthHeaders());
+    }
+
+    /// <summary>
+    /// Propagates the current <see cref="AuthToken"/> / <see cref="JwtToken"/> to all subsequent
+    /// outgoing requests as per-request headers. Call this after manually setting
+    /// <see cref="AuthToken"/> outside of <see cref="LoginAsync"/>.
+    /// </summary>
+    public void UpdateAuthHeaders()
+    {
+        updateAuthInRestRoutinen();
     }
 
     protected virtual void OnErrorOccured(ApiErrorArgs e)
@@ -215,7 +248,7 @@ public class WebRoutinenBase
             {
                 AuthToken = result;
                 _originalSettings.AuthToken = result;
-                initRestRoutinen();
+                updateAuthInRestRoutinen();
                 Status = "OK";
                 return true;
             }
@@ -252,11 +285,23 @@ public class WebRoutinenBase
         }
     }
 
+    /// <summary>
+    /// Erneuert das Auth-Token am Endpunkt /api/Login/Update und aktualisiert
+    /// die Instanz sowie alle ausgehenden Requests sofort mit dem neuen Token.
+    /// Konsistent mit dem Verhalten von <see cref="LoginAsync"/>.
+    /// </summary>
     public async Task<UserAuthTokenDTO> RefreshTokenAsync(Guid authTokenGuid)
     {
         try
         {
-            return await PutAsync<UserAuthTokenDTO>("/api/Login/Update", new UserAuthTokenDTO { Token = authTokenGuid }, null, true);
+            var result = await PutAsync<UserAuthTokenDTO>("/api/Login/Update", new UserAuthTokenDTO { Token = authTokenGuid }, null, true);
+            if (result != null)
+            {
+                AuthToken = result;
+                _originalSettings.AuthToken = result;
+                updateAuthInRestRoutinen();
+            }
+            return result;
         }
         catch (Exception)
         {
@@ -572,6 +617,7 @@ public class WebRoutinenBase
                 jc.JwtToken = newJwt;
             }
             JwtToken = newJwt;
+            updateAuthInRestRoutinen();
             return true;
         }
         catch (ApiException apiEx)

--- a/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
+++ b/Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0;net48</TargetFrameworks>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CS1591;</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU1900;</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -29,7 +29,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <WarningsAsErrors>$(WarningsAsErrors);NU1605;CA1416</WarningsAsErrors>
-    <NoWarn>CS0067;CS1572;CS1573;CS1591;</NoWarn>
+    <NoWarn>CS0067;CS1572;CS1573;CS1591;NU1900;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.cs
+++ b/Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.cs
@@ -27,13 +27,12 @@ internal sealed class ErrorEnrichmentHandler : DelegatingHandler
                 return response;
 
             // Pre-read the response body so it is available for exception enrichment.
-            responseContent = response.Content != null
+            responseContent =
 #if NET5_0_OR_GREATER
-                ? await response.Content.ReadAsStringAsync(cancellationToken)
+                await response.Content.ReadAsStringAsync(cancellationToken);
 #else
-                ? await response.Content.ReadAsStringAsync()
+                await response.Content.ReadAsStringAsync();
 #endif
-                : null;
 
             response.EnsureSuccessStatusCode(); // always throws here since !IsSuccessStatusCode
             return response; // unreachable, satisfies compiler

--- a/Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.cs
+++ b/Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gandalan.IDAS.WebApi.Client.Handlers;
+
+/// <summary>
+/// Intercepts non-success HTTP responses, pre-reads the response body, and enriches
+/// the resulting <see cref="HttpRequestException"/> with URL, status code, and response
+/// content in <see cref="Exception.Data"/> so that upstream callers (e.g.
+/// <c>WebRoutinenBase.TranslateException</c>) can produce meaningful <c>ApiException</c>
+/// instances without manual per-method boilerplate.
+/// </summary>
+internal sealed class ErrorEnrichmentHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = null;
+        string responseContent = null;
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+                return response;
+
+            // Pre-read the response body so it is available for exception enrichment.
+            responseContent = response.Content != null
+#if NET5_0_OR_GREATER
+                ? await response.Content.ReadAsStringAsync(cancellationToken)
+#else
+                ? await response.Content.ReadAsStringAsync()
+#endif
+                : null;
+
+            response.EnsureSuccessStatusCode(); // always throws here since !IsSuccessStatusCode
+            return response; // unreachable, satisfies compiler
+        }
+        catch (Exception ex) when (!ex.Data.Contains("URL"))
+        {
+            ex.Data["URL"] = request.RequestUri?.ToString();
+            ex.Data["StatusCode"] = response?.StatusCode ?? HttpStatusCode.InternalServerError;
+            if (!string.IsNullOrWhiteSpace(responseContent))
+                ex.Data["Response"] = responseContent;
+            throw;
+        }
+    }
+}

--- a/Gandalan.IDAS.WebApi.Client/Handlers/GatewayClusterHandler.cs
+++ b/Gandalan.IDAS.WebApi.Client/Handlers/GatewayClusterHandler.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gandalan.IDAS.WebApi.Client.Handlers;
+
+/// <summary>
+/// Adds the <c>X-Gateway-Cluster</c> header to outgoing requests whose URI path
+/// matches one of the configured opt-in endpoints for the new IDAS API backend.
+/// Configured per <see cref="HttpClient"/> via <see cref="HttpClientConfig.NewApiOptInUrls"/>.
+/// </summary>
+internal sealed class GatewayClusterHandler : DelegatingHandler
+{
+    private readonly string[] _newApiOptInUrls;
+
+    internal GatewayClusterHandler(string[] newApiOptInUrls)
+    {
+        _newApiOptInUrls = newApiOptInUrls;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (_newApiOptInUrls != null && _newApiOptInUrls.Length > 0)
+        {
+            var uriPath = request.RequestUri?.AbsolutePath;
+            if (uriPath != null && _newApiOptInUrls.Any(endpoint => IsPathMatchingEndpoint(uriPath, endpoint)))
+            {
+                request.Headers.TryAddWithoutValidation("X-Gateway-Cluster", "idas");
+            }
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Determines whether the specified URI path matches the given configured endpoint,
+    /// using a case-insensitive comparison and ensuring a valid path boundary.
+    /// </summary>
+    /// <param name="uriPath">The URI path to evaluate against the endpoint.</param>
+    /// <param name="endpoint">The endpoint to match at the start of the URI path. Trailing slashes are ignored. Cannot be null.</param>
+    /// <returns>true if the URI path starts with the endpoint and the match occurs at a valid path boundary; otherwise, false.</returns>
+    internal static bool IsPathMatchingEndpoint(string uriPath, string endpoint)
+    {
+        if (endpoint == null) return false;
+
+        var normalizedEndpoint = endpoint.TrimEnd('/');
+
+        return uriPath.StartsWith(normalizedEndpoint, StringComparison.OrdinalIgnoreCase)
+            && HasValidPathBoundary(uriPath, normalizedEndpoint.Length);
+    }
+
+    /// <summary>
+    /// Determines whether the specified endpoint length is at a valid boundary within the given URI path.
+    /// Configured endpoint paths should only match complete segments of the URI path:
+    /// We want to hit /api/Login if it's configured not /api/LoginJwt
+    /// </summary>
+    /// <param name="uriPath">The URI path to evaluate. Cannot be null.</param>
+    /// <param name="endpointLength">The position within the URI path to check for a valid boundary.</param>
+    /// <returns>true if the endpoint length is at the end of the URI path or is immediately followed by a '/' or '?'; otherwise, false.</returns>
+    internal static bool HasValidPathBoundary(string uriPath, int endpointLength)
+        => endpointLength >= uriPath.Length
+            || uriPath[endpointLength] == '/'
+            || uriPath[endpointLength] == '?';
+}

--- a/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
+++ b/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 
@@ -44,6 +45,15 @@ public class HttpClientConfig : ICloneable
     /// </summary>
     public string[] NewApiOptInUrls { get; set; }
 
+    /// <summary>
+    /// Maximum number of concurrent TCP connections per server endpoint.
+    /// On .NET Framework 4.8, <see cref="System.Net.HttpWebRequest"/> routes through
+    /// <see cref="System.Net.ServicePointManager"/> which defaults to 2 — far too low
+    /// for applications making parallel API calls. This property raises that limit.
+    /// On .NET 8+, <c>SocketsHttpHandler</c> already uses <see cref="int.MaxValue"/> internally.
+    /// </summary>
+    public int MaxConnectionsPerServer { get; set; } = 30;
+
     public object Clone()
     {
         return new HttpClientConfig
@@ -54,7 +64,8 @@ public class HttpClientConfig : ICloneable
             UserAgent = UserAgent,
             UseCompression = UseCompression,
             AdditionalHeaders = new Dictionary<string, string>(AdditionalHeaders),
-            NewApiOptInUrls = NewApiOptInUrls
+            NewApiOptInUrls = NewApiOptInUrls,
+            MaxConnectionsPerServer = MaxConnectionsPerServer
         };
     }
 
@@ -87,44 +98,69 @@ public class HttpClientConfig : ICloneable
         }
 
         // Compare NewApiOptInUrls
-        if (NewApiOptInUrls == null != (other.NewApiOptInUrls == null))
+        if (!NullableSequenceEqual(NewApiOptInUrls, other.NewApiOptInUrls))
             return false;
-        if (NewApiOptInUrls != null)
-        {
-            if (NewApiOptInUrls.Length != other.NewApiOptInUrls.Length)
-                return false;
-            for (int i = 0; i < NewApiOptInUrls.Length; i++)
-            {
-                if (!string.Equals(NewApiOptInUrls[i], other.NewApiOptInUrls[i], StringComparison.Ordinal))
-                    return false;
-            }
-        }
+
+        if (MaxConnectionsPerServer != other.MaxConnectionsPerServer)
+            return false;
 
         return true;
     }
 
+    private static bool NullableSequenceEqual(string[] a, string[] b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        return a.SequenceEqual(b, StringComparer.Ordinal);
+    }
+
     public override int GetHashCode()
     {
-        // Hash each property and combine them to generate a unique hash
-        var hash = BaseUrl.GetHashCode() ^ UseCompression.GetHashCode() ^ (UserAgent?.GetHashCode() ?? 0);
-        if (Credentials != null)
+        // NOTE: HttpClientConfig is used as a dictionary key and must not be mutated
+        // after being added to a dictionary. Properties are mutable by design for
+        // construction convenience, but treat instances as effectively immutable once in use.
+#if NETFRAMEWORK
+        unchecked
         {
-            hash ^= Credentials.GetHashCode();
+            int hash = 17;
+            hash = hash * 31 + (BaseUrl?.GetHashCode() ?? 0);
+            hash = hash * 31 + UseCompression.GetHashCode();
+            hash = hash * 31 + (UserAgent != null ? StringComparer.Ordinal.GetHashCode(UserAgent) : 0);
+            hash = hash * 31 + (Credentials?.GetHashCode() ?? 0);
+            hash = hash * 31 + (Proxy?.GetHashCode() ?? 0);
+            foreach (var header in AdditionalHeaders)
+            {
+                hash = hash * 31 + StringComparer.Ordinal.GetHashCode(header.Key);
+                hash = hash * 31 + StringComparer.Ordinal.GetHashCode(header.Value);
+            }
+            if (NewApiOptInUrls != null)
+            {
+                foreach (var url in NewApiOptInUrls)
+                    hash = hash * 31 + (url != null ? StringComparer.Ordinal.GetHashCode(url) : 0);
+            }
+            hash = hash * 31 + MaxConnectionsPerServer.GetHashCode();
+            return hash;
         }
-        if (Proxy != null)
-        {
-            hash ^= Proxy.GetHashCode();
-        }
+#else
+        var hash = new HashCode();
+        hash.Add(BaseUrl);
+        hash.Add(UseCompression);
+        hash.Add(UserAgent, StringComparer.Ordinal);
+        hash.Add(Credentials);
+        hash.Add(Proxy);
         foreach (var header in AdditionalHeaders)
         {
-            hash ^= header.Key.GetHashCode() ^ header.Value.GetHashCode();
+            hash.Add(header.Key, StringComparer.Ordinal);
+            hash.Add(header.Value, StringComparer.Ordinal);
         }
         if (NewApiOptInUrls != null)
         {
             foreach (var url in NewApiOptInUrls)
-                hash ^= url?.GetHashCode() ?? 0;
+                hash.Add(url, StringComparer.Ordinal);
         }
-        return hash;
+        hash.Add(MaxConnectionsPerServer);
+        return hash.ToHashCode();
+#endif
     }
 }
 
@@ -172,6 +208,17 @@ public class HttpClientFactory
             Credentials = config.Credentials,
             Proxy = config.Proxy
         };
+
+#if NETFRAMEWORK
+        // .NET Framework routes HttpClient through ServicePointManager, which caps
+        // concurrent TCP connections per host at 2 by default. Raise it explicitly
+        // so parallel API calls are not serialised at the socket level.
+        if (Uri.TryCreate(config.BaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            ServicePointManager.FindServicePoint(baseUri).ConnectionLimit = config.MaxConnectionsPerServer;
+        }
+#endif
+
         pipeline = new GatewayClusterHandler(config.NewApiOptInUrls) { InnerHandler = pipeline };
         pipeline = new ErrorEnrichmentHandler { InnerHandler = pipeline };
 

--- a/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
+++ b/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
@@ -51,7 +51,8 @@ public class HttpClientConfig : ICloneable
             Credentials = Credentials,
             UserAgent = UserAgent,
             UseCompression = UseCompression,
-            AdditionalHeaders = new Dictionary<string, string>(AdditionalHeaders)
+            AdditionalHeaders = new Dictionary<string, string>(AdditionalHeaders),
+            NewApiOptInUrls = NewApiOptInUrls
         };
     }
 

--- a/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
+++ b/Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 
+using Gandalan.IDAS.WebApi.Client.Handlers;
+
 namespace Gandalan.IDAS.WebApi.Client;
 
 public class HttpClientConfig : ICloneable
@@ -84,6 +86,20 @@ public class HttpClientConfig : ICloneable
             }
         }
 
+        // Compare NewApiOptInUrls
+        if (NewApiOptInUrls == null != (other.NewApiOptInUrls == null))
+            return false;
+        if (NewApiOptInUrls != null)
+        {
+            if (NewApiOptInUrls.Length != other.NewApiOptInUrls.Length)
+                return false;
+            for (int i = 0; i < NewApiOptInUrls.Length; i++)
+            {
+                if (!string.Equals(NewApiOptInUrls[i], other.NewApiOptInUrls[i], StringComparison.Ordinal))
+                    return false;
+            }
+        }
+
         return true;
     }
 
@@ -102,6 +118,11 @@ public class HttpClientConfig : ICloneable
         foreach (var header in AdditionalHeaders)
         {
             hash ^= header.Key.GetHashCode() ^ header.Value.GetHashCode();
+        }
+        if (NewApiOptInUrls != null)
+        {
+            foreach (var url in NewApiOptInUrls)
+                hash ^= url?.GetHashCode() ?? 0;
         }
         return hash;
     }
@@ -143,14 +164,18 @@ public class HttpClientFactory
     /// </summary>
     private static HttpClient createWebClient(HttpClientConfig config)
     {
-        var handler = new HttpClientHandler
+        // Build the DelegatingHandler pipeline:
+        // ErrorEnrichmentHandler → GatewayClusterHandler → HttpClientHandler
+        HttpMessageHandler pipeline = new HttpClientHandler
         {
             AutomaticDecompression = config.UseCompression ? DecompressionMethods.GZip | DecompressionMethods.Deflate : DecompressionMethods.None,
             Credentials = config.Credentials,
             Proxy = config.Proxy
         };
+        pipeline = new GatewayClusterHandler(config.NewApiOptInUrls) { InnerHandler = pipeline };
+        pipeline = new ErrorEnrichmentHandler { InnerHandler = pipeline };
 
-        var client = new HttpClient(handler);
+        var client = new HttpClient(pipeline);
         client.BaseAddress = new Uri(config.BaseUrl);
         client.DefaultRequestHeaders.Add("Accept-Charset", "utf-8");
         client.DefaultRequestHeaders.Add("Accept", "application/json");

--- a/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
@@ -64,7 +64,7 @@ public class RESTRoutinen : IDisposable
 
     /// <summary>
     /// Replaces the set of headers that are added to every outgoing request (e.g. auth headers).
-    /// Thread-safe via an atomic reference swap — in-flight requests use the previous snapshot.
+    /// Thread-safe via an atomic reference swap -- in-flight requests use the previous snapshot.
     /// </summary>
     internal void UpdatePerRequestHeaders(Dictionary<string, string> headers)
     {
@@ -242,7 +242,7 @@ public class RESTRoutinen : IDisposable
     {
         var request = new HttpRequestMessage(method, url);
 
-        var perRequest = _perRequestHeaders; // single volatile read for consistency
+        var perRequest = _perRequestHeaders; // single volatile read -- consistent snapshot
         if (perRequest != null)
         {
             foreach (var kvp in perRequest)

--- a/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -21,7 +22,7 @@ public class RESTRoutinen : IDisposable
 {
     private readonly HttpClientConfig _config;
     private readonly HttpClient _client;
-    private readonly Dictionary<string, HttpClient> _versionClients = [];
+    private readonly ConcurrentDictionary<string, HttpClient> _versionClients = new();
 
     #region Constructors
 
@@ -77,10 +78,9 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.GetAsync(url);
+            var request = BuildRequestMessage(HttpMethod.Get, url);
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return contentAsString;
@@ -98,10 +98,9 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.GetAsync(url);
+            var request = BuildRequestMessage(HttpMethod.Get, url);
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return await response.Content?.ReadAsByteArrayAsync();
@@ -134,11 +133,11 @@ public class RESTRoutinen : IDisposable
 
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var json = JsonConvert.SerializeObject(data, settings);
             var client = GetClientByVersion(version);
-            response = await client.PostAsync(url, new StringContent(json, Encoding.UTF8, "application/json"));
+            var request = BuildRequestMessage(HttpMethod.Post, url);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return contentAsString;
@@ -156,10 +155,10 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.PostAsync(url, new ByteArrayContent(data));
+            var request = BuildRequestMessage(HttpMethod.Post, url);
+            request.Content = new ByteArrayContent(data);
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return await response.Content?.ReadAsByteArrayAsync();
@@ -177,10 +176,10 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.PostAsync(url, data);
+            var request = BuildRequestMessage(HttpMethod.Post, url);
+            request.Content = data;
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return await response.Content?.ReadAsByteArrayAsync();
@@ -212,11 +211,11 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var json = JsonConvert.SerializeObject(data, settings);
             var client = GetClientByVersion(version);
-            response = await client.PutAsync(url, new StringContent(json, Encoding.UTF8, "application/json"));
+            var request = BuildRequestMessage(HttpMethod.Put, url);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
             return contentAsString;
@@ -234,10 +233,10 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.PutAsync(url, new ByteArrayContent(data));
+            var request = BuildRequestMessage(HttpMethod.Put, url);
+            request.Content = new ByteArrayContent(data);
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             return await response.Content?.ReadAsByteArrayAsync();
         }
@@ -254,10 +253,10 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.PutAsync(url, data);
+            var request = BuildRequestMessage(HttpMethod.Put, url);
+            request.Content = data;
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             return await response.Content?.ReadAsByteArrayAsync();
         }
@@ -280,10 +279,9 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            response = await client.DeleteAsync(url);
+            var request = BuildRequestMessage(HttpMethod.Delete, url);
+            response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
             response.EnsureSuccessStatusCode();
         }
@@ -300,15 +298,9 @@ public class RESTRoutinen : IDisposable
         HttpResponseMessage response = null;
         try
         {
-            ValidateAndApplyNewApiHeader(url);
-
             var client = GetClientByVersion(version);
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Delete,
-                RequestUri = new Uri(client.BaseAddress, url),
-                Content = new StringContent(JsonConvert.SerializeObject(data, settings), Encoding.UTF8, "application/json")
-            };
+            var request = BuildRequestMessage(HttpMethod.Delete, url);
+            request.Content = new StringContent(JsonConvert.SerializeObject(data, settings), Encoding.UTF8, "application/json");
 
             response = await client.SendAsync(request);
             contentAsString = await response.Content?.ReadAsStringAsync();
@@ -351,72 +343,43 @@ public class RESTRoutinen : IDisposable
             return _client;
         }
 
-        if (!_versionClients.TryGetValue(version, out var versionClient))
+        return _versionClients.GetOrAdd(version, v =>
         {
             var config = (HttpClientConfig)_config.Clone();
-            config.AdditionalHeaders.Add("api-version", version);
-
-            _versionClients.Add(version, HttpClientFactory.GetInstance(config));
-            return _versionClients[version];
-        }
-
-        return versionClient;
+            config.AdditionalHeaders.Add("api-version", v);
+            return HttpClientFactory.GetInstance(config);
+        });
     }
 
     /// <summary>
-    /// Adds a header to the default request headers of the HTTP client.
+    /// Builds an <see cref="HttpRequestMessage"/> and applies the X-Gateway-Cluster header
+    /// per-request without mutating the shared <see cref="HttpClient.DefaultRequestHeaders"/>.
     /// </summary>
-    /// <param name="headerName">The name of the header</param>
-    /// <param name="headerValue">The value of the header</param>
-    public void AddHeader(string headerName, string headerValue)
+    private HttpRequestMessage BuildRequestMessage(HttpMethod method, string url)
     {
-        if (!_client.DefaultRequestHeaders.Contains(headerName))
-        {
-            _client.DefaultRequestHeaders.Add(headerName, headerValue);
-        }
+        var request = new HttpRequestMessage(method, url);
+        var clusterHeaderValue = ResolveGatewayClusterHeader(url);
+        if (clusterHeaderValue != null)
+            request.Headers.TryAddWithoutValidation("X-Gateway-Cluster", clusterHeaderValue);
+        return request;
     }
 
     /// <summary>
-    /// Removes the specified HTTP header from the default request headers collection.
+    /// Determines the X-Gateway-Cluster header value for the given URL without mutating any shared state.
+    /// Returns "idas" if the URL matches a new-API opt-in endpoint, otherwise null.
     /// </summary>
-    /// <remarks>If the specified header does not exist in the collection, no action is taken.</remarks>
-    /// <param name="headerName">The name of the HTTP header to remove. The comparison is case-insensitive.</param>
-    public void RemoveHeader(string headerName)
+    private string ResolveGatewayClusterHeader(string relativeUri)
     {
-        _client.DefaultRequestHeaders.Remove(headerName);
-    }
-
-    /// <summary>
-    /// Validates whether the specified relative URI should opt in to the new API and applies the appropriate API header
-    /// to the HTTP client request.
-    /// </summary>
-    /// <remarks>If the configuration does not specify any opt-in endpoints, the method ensures the
-    /// 'X-Gateway-Cluster' header is removed. If the relative URI matches an opt-in endpoint, the header is set to
-    /// indicate use of the new API. This method should be called before sending a request to ensure the correct API
-    /// header is applied.</remarks>
-    /// <param name="relativeUri">The relative URI of the request to evaluate for new API opt-in. Must not be null or empty.</param>
-    private void ValidateAndApplyNewApiHeader(string relativeUri)
-    {
-        var config = _client.BaseAddress != null
-            ? _config
-            : null;
-
+        var config = _client.BaseAddress != null ? _config : null;
         if (config?.NewApiOptInUrls == null || config.NewApiOptInUrls.Length == 0)
-        {
-            RemoveHeader("X-Gateway-Cluster");
-            return;
-        }
+            return null;
 
         var fullUri = new Uri(_client.BaseAddress, relativeUri);
         var uriPath = fullUri.AbsolutePath;
 
-        var shouldUseNewApi = config.NewApiOptInUrls.Any(endpoint =>
-            IsPathMatchingEndpoint(uriPath, endpoint));
-
-        if (shouldUseNewApi)
-            AddHeader("X-Gateway-Cluster", "idas");
-        else
-            RemoveHeader("X-Gateway-Cluster");
+        return config.NewApiOptInUrls.Any(endpoint => IsPathMatchingEndpoint(uriPath, endpoint))
+            ? "idas"
+            : null;
     }
 
     /// <summary>

--- a/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
@@ -48,6 +48,11 @@ public class RESTRoutinen : IDisposable
 
     #endregion Constructors
 
+    /// <summary>
+    /// Setting the UserAgent on a shared <see cref="HttpClient"/> is not thread-safe.
+    /// Configure the UserAgent via <see cref="HttpClientConfig.UserAgent"/> instead.
+    /// </summary>
+    [Obsolete("Setting UserAgent on a shared HttpClient is not thread-safe. Use HttpClientConfig.UserAgent instead.")]
     public string UserAgent
     {
         set
@@ -55,6 +60,17 @@ public class RESTRoutinen : IDisposable
             _client.DefaultRequestHeaders.UserAgent.Clear();
             _client.DefaultRequestHeaders.UserAgent.TryParseAdd(value);
         }
+    }
+
+    private volatile Dictionary<string, string> _perRequestHeaders;
+
+    /// <summary>
+    /// Replaces the set of headers that are added to every outgoing request (e.g. auth headers).
+    /// Thread-safe via an atomic reference swap — in-flight requests use the previous snapshot.
+    /// </summary>
+    internal void UpdatePerRequestHeaders(Dictionary<string, string> headers)
+    {
+        _perRequestHeaders = headers != null ? new Dictionary<string, string>(headers) : null;
     }
 
     #region public Methods
@@ -352,12 +368,20 @@ public class RESTRoutinen : IDisposable
     }
 
     /// <summary>
-    /// Builds an <see cref="HttpRequestMessage"/> and applies the X-Gateway-Cluster header
-    /// per-request without mutating the shared <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// Builds an <see cref="HttpRequestMessage"/> and applies per-request headers
+    /// (auth, X-Gateway-Cluster) without mutating the shared <see cref="HttpClient.DefaultRequestHeaders"/>.
     /// </summary>
     private HttpRequestMessage BuildRequestMessage(HttpMethod method, string url)
     {
         var request = new HttpRequestMessage(method, url);
+
+        var perRequest = _perRequestHeaders; // single volatile read for consistency
+        if (perRequest != null)
+        {
+            foreach (var kvp in perRequest)
+                request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+        }
+
         var clusterHeaderValue = ResolveGatewayClusterHeader(url);
         if (clusterHeaderValue != null)
             request.Headers.TryAddWithoutValidation("X-Gateway-Cluster", clusterHeaderValue);

--- a/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -90,42 +88,18 @@ public class RESTRoutinen : IDisposable
 
     public async Task<string> GetAsync(string url, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Get, url);
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return contentAsString;
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Get, url);
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsStringAsync();
     }
 
     public async Task<byte[]> GetDataAsync(string url, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Get, url);
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return await response.Content?.ReadAsByteArrayAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Get, url);
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsByteArrayAsync();
     }
 
     /// <summary>
@@ -144,67 +118,30 @@ public class RESTRoutinen : IDisposable
 
     public async Task<string> PostAsync(string url, object data, JsonSerializerSettings settings = null, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-
-        try
-        {
-            var json = JsonConvert.SerializeObject(data, settings);
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Post, url);
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return contentAsString;
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var json = JsonConvert.SerializeObject(data, settings);
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Post, url);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsStringAsync();
     }
 
     public async Task<byte[]> PostDataAsync(string url, byte[] data, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Post, url);
-            request.Content = new ByteArrayContent(data);
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return await response.Content?.ReadAsByteArrayAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Post, url);
+        request.Content = new ByteArrayContent(data);
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsByteArrayAsync();
     }
 
     public async Task<byte[]> PostDataAsync(string url, HttpContent data, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Post, url);
-            request.Content = data;
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return await response.Content?.ReadAsByteArrayAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Post, url);
+        request.Content = data;
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsByteArrayAsync();
     }
 
     /// <summary>
@@ -223,64 +160,30 @@ public class RESTRoutinen : IDisposable
 
     public async Task<string> PutAsync(string url, object data, JsonSerializerSettings settings = null, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var json = JsonConvert.SerializeObject(data, settings);
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Put, url);
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return contentAsString;
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var json = JsonConvert.SerializeObject(data, settings);
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Put, url);
+        request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsStringAsync();
     }
 
     public async Task<byte[]> PutDataAsync(string url, byte[] data, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Put, url);
-            request.Content = new ByteArrayContent(data);
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            return await response.Content?.ReadAsByteArrayAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Put, url);
+        request.Content = new ByteArrayContent(data);
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsByteArrayAsync();
     }
 
     public async Task<byte[]> PutDataAsync(string url, HttpContent data, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Put, url);
-            request.Content = data;
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            return await response.Content?.ReadAsByteArrayAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Put, url);
+        request.Content = data;
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsByteArrayAsync();
     }
 
     /// <summary>
@@ -291,43 +194,18 @@ public class RESTRoutinen : IDisposable
     /// <returns>Antwort des Servers als String</returns>
     public async Task DeleteAsync(string url, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Delete, url);
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Delete, url);
+        await client.SendAsync(request);
     }
 
     public async Task<string> DeleteAsync(string url, object data, JsonSerializerSettings settings = null, string version = null)
     {
-        string contentAsString = null;
-        HttpResponseMessage response = null;
-        try
-        {
-            var client = GetClientByVersion(version);
-            var request = BuildRequestMessage(HttpMethod.Delete, url);
-            request.Content = new StringContent(JsonConvert.SerializeObject(data, settings), Encoding.UTF8, "application/json");
-
-            response = await client.SendAsync(request);
-            contentAsString = await response.Content?.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-            return await response.Content?.ReadAsStringAsync();
-        }
-        catch (Exception ex)
-        {
-            AddInfoToException(ex, url, response, contentAsString);
-            throw;
-        }
+        var client = GetClientByVersion(version);
+        var request = BuildRequestMessage(HttpMethod.Delete, url);
+        request.Content = new StringContent(JsonConvert.SerializeObject(data, settings), Encoding.UTF8, "application/json");
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsStringAsync();
     }
 
     public async Task<T> DeleteAsync<T>(string url, object data, JsonSerializerSettings settings = null, string version = null)
@@ -336,17 +214,6 @@ public class RESTRoutinen : IDisposable
     }
 
     #endregion
-
-    private void AddInfoToException(Exception ex, string url, HttpResponseMessage response = null, string responseContent = null, [CallerMemberName] string sender = null)
-    {
-        ex.Data.Add("URL", new Uri(_client.BaseAddress, url).ToString());
-        ex.Data.Add("CallMethod", sender);
-        ex.Data.Add("StatusCode", response?.StatusCode ?? HttpStatusCode.InternalServerError);
-        if (!string.IsNullOrWhiteSpace(responseContent))
-        {
-            ex.Data.Add("Response", responseContent);
-        }
-    }
 
     public void Dispose()
     {
@@ -369,7 +236,7 @@ public class RESTRoutinen : IDisposable
 
     /// <summary>
     /// Builds an <see cref="HttpRequestMessage"/> and applies per-request headers
-    /// (auth, X-Gateway-Cluster) without mutating the shared <see cref="HttpClient.DefaultRequestHeaders"/>.
+    /// (auth) without mutating the shared <see cref="HttpClient.DefaultRequestHeaders"/>.
     /// </summary>
     private HttpRequestMessage BuildRequestMessage(HttpMethod method, string url)
     {
@@ -382,58 +249,6 @@ public class RESTRoutinen : IDisposable
                 request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
         }
 
-        var clusterHeaderValue = ResolveGatewayClusterHeader(url);
-        if (clusterHeaderValue != null)
-            request.Headers.TryAddWithoutValidation("X-Gateway-Cluster", clusterHeaderValue);
         return request;
     }
-
-    /// <summary>
-    /// Determines the X-Gateway-Cluster header value for the given URL without mutating any shared state.
-    /// Returns "idas" if the URL matches a new-API opt-in endpoint, otherwise null.
-    /// </summary>
-    private string ResolveGatewayClusterHeader(string relativeUri)
-    {
-        var config = _client.BaseAddress != null ? _config : null;
-        if (config?.NewApiOptInUrls == null || config.NewApiOptInUrls.Length == 0)
-            return null;
-
-        var fullUri = new Uri(_client.BaseAddress, relativeUri);
-        var uriPath = fullUri.AbsolutePath;
-
-        return config.NewApiOptInUrls.Any(endpoint => IsPathMatchingEndpoint(uriPath, endpoint))
-            ? "idas"
-            : null;
-    }
-
-    /// <summary>
-    /// Determines whether the specified URI path matches the given configured endpoint, using a case-insensitive comparison and
-    /// ensuring a valid path boundary.
-    /// </summary>
-    /// <param name="uriPath">The URI path to evaluate against the endpoint. This value is compared to the start of the endpoint string.</param>
-    /// <param name="endpoint">The endpoint to match at the start of the URI path. Trailing slashes are ignored. Cannot be null.</param>
-    /// <returns>true if the URI path starts with the endpoint and the match occurs at a valid path boundary; otherwise, false.</returns>
-    private static bool IsPathMatchingEndpoint(string uriPath, string endpoint)
-    {
-        if (endpoint == null) return false;
-
-        var normalizedEndpoint = endpoint.TrimEnd('/');
-
-        return uriPath.StartsWith(normalizedEndpoint, StringComparison.OrdinalIgnoreCase)
-            && HasValidPathBoundary(uriPath, normalizedEndpoint.Length);
-    }
-
-    /// <summary>
-    /// Determines whether the specified endpoint length is at a valid boundary within the given URI path.
-    /// Configured endpoint paths should only match complete segments of the URI path:
-    /// We want to hit /api/Login if it's configured not /api/LoginJwt
-    /// </summary>
-    /// <param name="uriPath">The URI path to evaluate. Cannot be null.</param>
-    /// <param name="endpointLength">The position within the URI path to check for a valid boundary. Must be greater than or equal to 0.</param>
-    /// <returns>true if the endpoint length is at the end of the URI path or is immediately followed by a '/' or '?'; otherwise,
-    /// false.</returns>
-    private static bool HasValidPathBoundary(string uriPath, int endpointLength)
-        => endpointLength >= uriPath.Length
-            || uriPath[endpointLength] == '/'
-            || uriPath[endpointLength] == '?';
 }


### PR DESCRIPTION
This pull request introduces significant improvements to authentication handling, error enrichment, and HTTP client configuration in the `Gandalan.IDAS.WebApi.Client` library. The main focus is on making authentication header management safer and more dynamic, enriching error information for better diagnostics, and supporting opt-in endpoints for a new API backend via HTTP headers. Thread safety and maintainability are also improved throughout the codebase.

**Authentication and Header Management Improvements:**

* Refactored authentication header handling in `WebRoutinenBase`: Auth headers (JWT and AuthToken) are now injected per-request rather than being set globally, ensuring that token refreshes do not require recreating `HttpClient` instances. Added thread-safe initialization and updating of headers, including a new `UpdateAuthHeaders` method for propagating changes. (`Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs` [[1]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304L38-R40) [[2]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304R92-R102) [[3]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304R156-R197) [[4]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304L218-R251) [[5]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304R288-R304) [[6]](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304R620)
* Made the per-request headers in `RESTRoutinen` thread-safe and updatable atomically, so in-flight requests can safely use previous header snapshots. (`Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs` [Gandalan.IDAS.WebApi.Client/RESTRoutinen.csR63-R73](diffhunk://#diff-f06e8c9338ad557e802ffc2091cde3a274550531d0804b78290b6bc09c470503R63-R73))
* Marked `UserAgent` property in `RESTRoutinen` as obsolete to discourage unsafe usage on shared clients. (`Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs` [Gandalan.IDAS.WebApi.Client/RESTRoutinen.csR49-R53](diffhunk://#diff-f06e8c9338ad557e802ffc2091cde3a274550531d0804b78290b6bc09c470503R49-R53))

**Error Handling Enhancements:**

* Introduced `ErrorEnrichmentHandler`, a new delegating handler that enriches exceptions with URL, status code, and response content, making error diagnostics more robust and removing the need for manual exception enrichment in each method. (`Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.cs` [Gandalan.IDAS.WebApi.Client/Handlers/ErrorEnrichmentHandler.csR1-R50](diffhunk://#diff-81ef86b8a89e76c96dcc8ac12feae988bb586eb4c7c435a4ec0f6b4a23f8c0ceR1-R50))
* Improved error data population in `InternalHandleWebException` to ensure the `CallMethod` key is always set and that error enrichment is more reliable, especially when exceptions are wrapped. (`Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.cs` [Gandalan.IDAS.WebApi.Client/BusinessRoutinen/WebRoutinenBase.csL708-R784](diffhunk://#diff-68c85ec4b3a1b80cf283cc6f827950a9382df444944e3dbce2a92c54d83f3304L708-R784))

**HTTP Client Pipeline and API Opt-In Support:**

* Added `GatewayClusterHandler`, which sets an `X-Gateway-Cluster: idas` header for requests to opt-in endpoints, supporting migration to a new backend API. (`Gandalan.IDAS.WebApi.Client/Handlers/GatewayClusterHandler.cs` [Gandalan.IDAS.WebApi.Client/Handlers/GatewayClusterHandler.csR1-R66](diffhunk://#diff-da80ff8599b273f721b388855516aecbe961bf0baca5a26b058ad40b0cb40b40R1-R66))
* Modified `HttpClientFactory` to compose the HTTP pipeline with `ErrorEnrichmentHandler` and `GatewayClusterHandler`, and to ensure `HttpClientConfig` is correctly cloned and compared when opt-in URLs are present. (`Gandalan.IDAS.WebApi.Client/HttpClientFactory.cs` [[1]](diffhunk://#diff-fc84de92ea56235789cd46c8c67a031862725ac3dc6d1ad5ff72a3c8b5c5e6e7R7-R8) [[2]](diffhunk://#diff-fc84de92ea56235789cd46c8c67a031862725ac3dc6d1ad5ff72a3c8b5c5e6e7L54-R57) [[3]](diffhunk://#diff-fc84de92ea56235789cd46c8c67a031862725ac3dc6d1ad5ff72a3c8b5c5e6e7R89-R102) [[4]](diffhunk://#diff-fc84de92ea56235789cd46c8c67a031862725ac3dc6d1ad5ff72a3c8b5c5e6e7R122-R126) [[5]](diffhunk://#diff-fc84de92ea56235789cd46c8c67a031862725ac3dc6d1ad5ff72a3c8b5c5e6e7L145-R178)

**Other Notable Changes:**

* Updated project files and disabled specific warnings for multi-targeting and package versioning. (`Gandalan.IDAS.WebApi.Client/Gandalan.IDAS.WebApi.Client.csproj` [[1]](diffhunk://#diff-4e71d0f625fe01d101482f2fa018e03784ffa3af34294a3cded9faaf63fcd505L19-R19) [[2]](diffhunk://#diff-4e71d0f625fe01d101482f2fa018e03784ffa3af34294a3cded9faaf63fcd505L32-R32)
* Added pragma to disable IDE warnings for explicit usings in multi-targeted DTO files. (`Gandalan.IDAS.WebApi.Client/DTOs/Belege/KapazitaetsvorgabenDTO.cs` [Gandalan.IDAS.WebApi.Client/DTOs/Belege/KapazitaetsvorgabenDTO.csR1](diffhunk://#diff-7af522f04cd3325362aceeb751296e7600b4287bf501e1cffe6e9c6c697c9e1eR1))
* Minor code cleanup and thread-safety improvements in `RESTRoutinen`. (`Gandalan.IDAS.WebApi.Client/RESTRoutinen.cs` [[1]](diffhunk://#diff-f06e8c9338ad557e802ffc2091cde3a274550531d0804b78290b6bc09c470503R2-L6) [[2]](diffhunk://#diff-f06e8c9338ad557e802ffc2091cde3a274550531d0804b78290b6bc09c470503L24-R23)

These changes collectively improve the reliability, maintainability, and future-proofing of the HTTP and authentication infrastructure in the client library.