### PR TITLE
NeherApp3: add iconAdaptive flag to NeherApp3MenuItem

### DIFF
--- a/WebLibs/api/neherApp3Types.js
+++ b/WebLibs/api/neherApp3Types.js
@@ -63,6 +63,7 @@
  * @property {string} [id] - Unique identifier for the menu item (auto-generated if not provided)
  * @property {boolean} [selected] - Indicates if the menu item is currently selected (managed by the menu system)
  * @property {string} [icon] - URL to an icon
+ * @property {boolean} [iconAdaptive] - If true, the icon adapts to the active theme (e.g. inverted in dark mode via the host's `icon-adaptive` styling).
  * @property {string | null} [url] - Relative URL to use for routes
  * @property {string} [text] - Display text (ignored for separator items)
  * @property {string | null} [parent] - Parent menu item (optional). If not set, the item will be added to the top level menu.

--- a/WebLibs/index.d.ts
+++ b/WebLibs/index.d.ts
@@ -2085,6 +2085,7 @@ export type NeherApp3MenuItem = {
     id?: string;
     selected?: boolean;
     icon?: string;
+    iconAdaptive?: boolean;
     url?: string | null;
     text?: string;
     parent?: string | null;


### PR DESCRIPTION
## What
Adds the optional `iconAdaptive` boolean to the `NeherApp3MenuItem` host type and regenerates `WebLibs/index.d.ts`.

## Why
NeherApp3 modules already pass `iconAdaptive: true` to `addMenuItem` to opt an icon into the host's `icon-adaptive` styling (e.g. inversion in dark mode). The field was missing from the type, producing `Object literal may only specify known properties, and 'iconAdaptive' does not exist in type 'NeherApp3MenuItem'` errors in consuming apps.

## Changes
- `WebLibs/api/neherApp3Types.js`: add `@property {boolean} [iconAdaptive]` to `NeherApp3MenuItem`
- `WebLibs/index.d.ts`: regenerated via `npm run generate:dts`

Verified: `tsc --noEmit` on the generated d.ts passes; `npm run lint` 0 errors. Version bump left to CI on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)