### PR TITLE
#15772 Händler archivieren: Result-DTO + WebRoutine (MandantenUmzug)

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/MandantenAdminWebRoutinen.cs
+++ b/Gandalan.IDAS.WebApi.Client/BusinessRoutinen/MandantenAdminWebRoutinen.cs
@@ -53,6 +53,13 @@ public class MandantenAdminWebRoutinen : WebRoutinenBase
 
     public async Task<string> MandantDeaktivierenAsync(string email)
         => await PostAsync<string>($"MandantenAdmin/MandantDeaktivieren?emailadresse={Uri.EscapeDataString(email)}", null);
-    
 
+    /// <summary>
+    /// Benennt die Anmelde-E-Mail eines Händlers um: legt einen neuen Benutzer mit der
+    /// neuen Adresse an, hängt alle Vorgänge um und archiviert die bisherigen Benutzer
+    /// des Mandanten. Erfordert serverseitig die Berechtigung <c>admin.mandantumzug</c>.
+    /// </summary>
+    public async Task<HaendlerArchivierenResultDTO> HaendlerArchivierenAsync(string alteMail, string neueMail)
+        => await PostAsync<HaendlerArchivierenResultDTO>(
+            $"HaendlerArchivieren?alteMail={Uri.EscapeDataString(alteMail)}&neueMail={Uri.EscapeDataString(neueMail)}", null);
 }

--- a/Gandalan.IDAS.WebApi.Client/DTOs/Benutzer/HaendlerArchivierenResultDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Benutzer/HaendlerArchivierenResultDTO.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gandalan.IDAS.WebApi.DTO;
+
+/// <summary>
+/// Ergebnis eines Händler-Archivieren-/E-Mail-Umbenennen-Vorgangs
+/// (api/HaendlerArchivieren). Wird sowohl vom Backend zurückgegeben als
+/// auch vom Client (NeherAdmin) zur Ergebnisanzeige deserialisiert.
+/// </summary>
+public class HaendlerArchivierenResultDTO
+{
+    /// <summary>True, wenn die DB-Umstellung erfolgreich committet wurde.</summary>
+    public bool Erfolgreich { get; set; }
+
+    public string AlteMail { get; set; }
+    public string NeueMail { get; set; }
+
+    /// <summary>Guid des neu angelegten Benutzers.</summary>
+    public Guid NeuerBenutzerGuid { get; set; }
+
+    /// <summary>Anzahl der auf den neuen Benutzer umgehängten Vorgänge.</summary>
+    public int VerschobeneVorgaenge { get; set; }
+
+    /// <summary>Anzahl der auf den neuen Benutzer umgehängten Vorgangs-ListItems.</summary>
+    public int VerschobeneVorgaengeListItems { get; set; }
+
+    /// <summary>Anzahl der archivierten (gelöschten) Alt-Benutzer.</summary>
+    public int ArchivierteBenutzer { get; set; }
+
+    /// <summary>
+    /// Nicht-fatale Warnungen (z.B. CMS-Synchronisierung oder Passwort-Mail
+    /// fehlgeschlagen). Die DB-Umstellung war in diesem Fall trotzdem erfolgreich.
+    /// </summary>
+    public List<string> Warnungen { get; set; } = new List<string>();
+
+    /// <summary>Menschenlesbare Zusammenfassung des Ergebnisses.</summary>
+    public string Meldung { get; set; }
+}


### PR DESCRIPTION
Teil von IDAS PBI #15769 / Task #15772 (E-Mail umbenennen / Händler archivieren als NeherAdmin-Funktion).

Fügt die Client-Seite für den neuen Backend-Endpoint `api/HaendlerArchivieren` hinzu:

- **Neu:** `HaendlerArchivierenResultDTO` (DTOs/Benutzer) – gemeinsames Result-DTO, das Backend UND Client nutzen (Zusammenfassung: neuer Benutzer, verschobene Vorgänge, archivierte Benutzer, Warnungen, Meldung).
- **Ergänzt:** `MandantenAdminWebRoutinen.HaendlerArchivierenAsync(alteMail, neueMail)` → `PostAsync<HaendlerArchivierenResultDTO>("HaendlerArchivieren?...")`, Emails via `Uri.EscapeDataString`.

Serverseitig durch Berechtigung `admin.mandantumzug` geschützt.

**Reihenfolge:** Dieser PR muss zuerst gemergt werden; danach bumpt der IDAS-Hauptrepo-PR den Submodul-Pointer.

Auf Linux gebaut (net8.0): 0 Warnungen, 0 Fehler.