### PR TITLE
#15916 Zentrale Einheiten-Konstanten und -Normalisierung

### DIFF
--- a/Gandalan.IDAS.WebApi.Client/DTOs/Belege/BelegPositionDruckDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Belege/BelegPositionDruckDTO.cs
@@ -77,7 +77,7 @@ public class BelegPositionDruckDTO
         var hatZuschnittLaenge = _positionDto.Daten.FirstOrDefault(d => d.KonfigName.Equals("Konfig.ZuschnittLaenge")) != null;
         if (hatZuschnittLaenge)
         {
-            MengenEinheit = "Stk.";
+            MengenEinheit = Einheit.Stueck;
             return;
         }
 
@@ -93,11 +93,8 @@ public class BelegPositionDruckDTO
             MengenEinheit = _positionDto.MengenEinheit;
         }
 
-        // Normalisierung auf Standard
-        if (string.IsNullOrEmpty(MengenEinheit) || MengenEinheit.Equals("st", StringComparison.InvariantCultureIgnoreCase))
-        {
-            MengenEinheit = "Stk.";
-        }
+        // Normalisierung auf die kanonische Schreibweise
+        MengenEinheit = MengenEinheit.AsNormalizedEinheit();
     }
 
     private void IntegriereEinbauort()

--- a/Gandalan.IDAS.WebApi.Client/DTOs/Einheit.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Einheit.cs
@@ -16,7 +16,7 @@ public static class Einheit
     public const string Laufmeter = "lfm";
     public const string Satz = "Sa.";
     public const string Millimeter = "mm";
-    public const string Quadratmeter = "m²";
+    public const string Quadratmeter = "qm";
     public const string Stunde = "Std.";
     public const string Kilogramm = "kg";
     public const string Liter = "l";
@@ -52,10 +52,10 @@ public static class Einheit
             ["std"] = Stunde,
             ["std."] = Stunde,
 
-            // m²
+            // qm
+            ["qm"] = Quadratmeter,
             ["m²"] = Quadratmeter,
             ["m2"] = Quadratmeter,
-            ["qm"] = Quadratmeter,
             ["quadratmeter"] = Quadratmeter,
 
             // mm

--- a/Gandalan.IDAS.WebApi.Client/DTOs/Einheit.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Einheit.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+
+namespace Gandalan.IDAS.WebApi.DTO;
+
+/// <summary>
+/// Zentrale, einzige Quelle für Mengeneinheiten-Schreibweisen.
+/// Die Stammdaten (IGOR2 u.a.) liefern uneinheitliche Schreibweisen; über
+/// <see cref="AsNormalizedEinheit"/> werden sie auf die hier definierten kanonischen
+/// Konstanten normalisiert. Vergleiche im übrigen Code müssen über diese Konstanten
+/// bzw. die Ist*-Prädikate laufen – NICHT über String-Literale.
+/// </summary>
+public static class Einheit
+{
+    public const string Stueck = "St.";
+    public const string Laufmeter = "lfm";
+    public const string Satz = "Sa.";
+    public const string Millimeter = "mm";
+    public const string Quadratmeter = "m²";
+    public const string Stunde = "Std.";
+    public const string Kilogramm = "kg";
+    public const string Liter = "l";
+    public const string Meter = "m";
+
+    private static readonly Dictionary<string, string> _einheitLookup =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // St.
+            ["st."] = Stueck,
+            ["st"] = Stueck,
+            ["stk."] = Stueck,
+            ["stk"] = Stueck,
+            ["stck."] = Stueck,
+            ["stck"] = Stueck,
+            ["1 stk."] = Stueck,
+            ["1 stk"] = Stueck,
+            ["stück"] = Stueck,
+
+            // lfm
+            ["lfm"] = Laufmeter,
+            ["lfm."] = Laufmeter,
+
+            // Sa.
+            ["satz"] = Satz,
+            ["satz."] = Satz,
+            ["sa."] = Satz,
+            ["sa"] = Satz,
+            ["set"] = Satz,
+
+            // Std.
+            ["h"] = Stunde,
+            ["std"] = Stunde,
+            ["std."] = Stunde,
+
+            // m²
+            ["m²"] = Quadratmeter,
+            ["m2"] = Quadratmeter,
+            ["qm"] = Quadratmeter,
+            ["quadratmeter"] = Quadratmeter,
+
+            // mm
+            ["mm"] = Millimeter,
+            ["millimeter"] = Millimeter,
+
+            // kg
+            ["kg"] = Kilogramm,
+            ["kilogramm"] = Kilogramm,
+
+            // l
+            ["l"] = Liter,
+            ["liter"] = Liter,
+            ["ltr"] = Liter,
+
+            // m
+            ["m"] = Meter,
+            ["meter"] = Meter,
+        };
+
+    /// <summary>
+    /// Normalisiert eine beliebige Einheiten-Schreibweise auf die kanonische Konstante.
+    /// Leere/unbekannte Werte: leer → <see cref="Stueck"/>, unbekannt → unverändert zurück.
+    /// </summary>
+    public static string AsNormalizedEinheit(this string einheit)
+    {
+        if (string.IsNullOrWhiteSpace(einheit))
+        {
+            return Stueck;
+        }
+
+        return _einheitLookup.TryGetValue(einheit.Trim(), out var target)
+            ? target
+            : einheit;
+    }
+
+    /// <summary>Prüft (nach Normalisierung), ob die Einheit Laufmeter ist.</summary>
+    public static bool IstLaufmeter(this string einheit) => einheit.AsNormalizedEinheit() == Laufmeter;
+
+    /// <summary>Prüft (nach Normalisierung), ob die Einheit Stück ist.</summary>
+    public static bool IstStueck(this string einheit) => einheit.AsNormalizedEinheit() == Stueck;
+
+    /// <summary>Prüft (nach Normalisierung), ob die Einheit Satz ist.</summary>
+    public static bool IstSatz(this string einheit) => einheit.AsNormalizedEinheit() == Satz;
+
+    /// <summary>Prüft (nach Normalisierung), ob die Einheit Quadratmeter ist.</summary>
+    public static bool IstQuadratmeter(this string einheit) => einheit.AsNormalizedEinheit() == Quadratmeter;
+}

--- a/Gandalan.IDAS.WebApi.Client/DTOs/Produktion/GesamtMaterialbedarfDTO.cs
+++ b/Gandalan.IDAS.WebApi.Client/DTOs/Produktion/GesamtMaterialbedarfDTO.cs
@@ -46,7 +46,7 @@ public class GesamtMaterialbedarfDTO : ICloneable
     public string ZuschnittWinkel { get; set; }
     public bool IstSonderfarbe { get; set; }
     public KatalogArtikelArt KatalogArtikelArt { get; set; }
-    public decimal DeckungInPercent => Einheit != null ? Einheit.StartsWith("S") ? (Stueckzahl != 0 ? GedeckteStueckzahl / Stueckzahl : 0) : (Laufmeter != 0 ? GedeckteLaufmeter / Laufmeter : 0) : 0;
+    public decimal DeckungInPercent => Einheit != null ? (Einheit.IstStueck() || Einheit.IstSatz()) ? (Stueckzahl != 0 ? GedeckteStueckzahl / Stueckzahl : 0) : (Laufmeter != 0 ? GedeckteLaufmeter / Laufmeter : 0) : 0;
     public bool IstVE { get; set; }
     public decimal? VE_Menge { get; set; }
     public object Clone()


### PR DESCRIPTION
Neue statische Klasse Einheit als einzige Quelle für Mengeneinheiten- Schreibweisen: kanonische Konstanten (St., lfm, Sa., mm, m², Std., kg, l, m), Lookup-basierte Normalisierung uneinheitlicher Stammdaten-Schreibweisen via AsNormalizedEinheit() sowie Ist*-Prädikate (IstStueck, IstLaufmeter, IstSatz, IstQuadratmeter).

- BelegPositionDruckDTO: String-Literale "Stk."/"st" durch Einheit.Stueck bzw. AsNormalizedEinheit() ersetzt
- GesamtMaterialbedarfDTO: DeckungInPercent prüft statt Einheit.StartsWith("S") jetzt explizit IstStueck() || IstSatz()