### PR TITLE
fix(weblibs): 401 beim ersten Request nach längerem Leerlauf verhindern

### DIFF
--- a/WebLibs/api/fluentApi.js
+++ b/WebLibs/api/fluentApi.js
@@ -1,4 +1,4 @@
-import { restClient } from "./fluentRestClient";
+import { restClient, RestError } from "./fluentRestClient";
 
 /**
  * @typedef {Object} FluentApi
@@ -16,6 +16,7 @@ import { restClient } from "./fluentRestClient";
  * @property {(url?: string, payload?: Object|FormData|Array<any>|string[]|string|null, auth?: boolean) => Promise<object|Array<any>>} delete - Async function to perform DELETE requests.
  * @property {() => import("./fluentRestClient").FluentRESTClient} createRestClient - Creates a configured REST client.
  * @property {(auth?: boolean) => Promise<void>} preCheck - Ensures authentication before a request when required.
+ * @property {(auth: boolean, executeRequest: () => Promise<any>) => Promise<any>} _executeRequest - Runs a request with authentication and a one-time retry on 401.
  */
 
 /**
@@ -82,8 +83,7 @@ export function createApi() {
          * @returns {Promise<Object>}
          */
         async get(url = "", auth = true, skipResponseParsing = false) {
-            await this.preCheck(auth);
-            return await this.createRestClient().get(url, auth, skipResponseParsing);
+            return await this._executeRequest(auth, () => this.createRestClient().get(url, auth, skipResponseParsing));
         },
 
         /**
@@ -97,8 +97,7 @@ export function createApi() {
          * @returns {Promise<Object>}
          */
         async put(url = "", payload = {}, auth = true, skipResponseParsing = false) {
-            await this.preCheck(auth);
-            return await this.createRestClient().put(url, payload, skipResponseParsing);
+            return await this._executeRequest(auth, () => this.createRestClient().put(url, payload, skipResponseParsing));
         },
 
         /**
@@ -112,8 +111,7 @@ export function createApi() {
          * @returns {Promise<Object>}
          */
         async post(url = "", payload = {}, auth = true, skipResponseParsing = false) {
-            await this.preCheck(auth);
-            return await this.createRestClient().post(url, payload, skipResponseParsing);
+            return await this._executeRequest(auth, () => this.createRestClient().post(url, payload, skipResponseParsing));
         },
 
         /**
@@ -127,8 +125,35 @@ export function createApi() {
          * @returns {Promise<Object>}
          */
         async delete(url = "", payload = null, auth = true, skipResponseParsing = false) {
+            return await this._executeRequest(auth, () => this.createRestClient().delete(url, payload, skipResponseParsing));
+        },
+
+        /**
+         * Runs a request with authentication and retries it once if the server
+         * answered 401 Unauthorized: the cached token is discarded, a fresh one
+         * is obtained via the auth manager and the request is repeated. This
+         * covers tokens that expired server-side (e.g. after hours of
+         * inactivity) as well as refresh races between parallel requests.
+         *
+         * @private
+         * @async
+         * @param {boolean} auth - Whether the request requires authentication.
+         * @param {() => Promise<any>} executeRequest - Performs the request; must create the rest client inside so a retry picks up the fresh token.
+         * @returns {Promise<any>}
+         */
+        async _executeRequest(auth, executeRequest) {
             await this.preCheck(auth);
-            return await this.createRestClient().delete(url, payload, skipResponseParsing);
+            try {
+                return await executeRequest();
+            } catch (e) {
+                if (!auth || !this.authManager || !(e instanceof RestError) || e.status !== 401) {
+                    throw e;
+                }
+
+                this.authManager.token = "";
+                await this.authManager.ensureAuthenticated();
+                return await executeRequest();
+            }
         },
 
         /**

--- a/WebLibs/api/fluentAuthManager.js
+++ b/WebLibs/api/fluentAuthManager.js
@@ -23,6 +23,8 @@ import { popRefreshTokenFromUrl } from "./fluentAuthUtils";
  * @property {(storedRefreshToken?: string|null) => FluentAuthManager} useRefreshToken - Sets the refresh token and returns the FluentApi object.
  * @property {() => Promise<void>} ensureAuthenticated - Ensures the user is authenticated before making a request.
  * @property {() => Promise<void>} authenticate - Authenticates the user with username and password, or refreshes the token.
+ * @property {() => Promise<void>} _doAuthenticate - Performs the actual token refresh (single-flight worker behind authenticate).
+ * @property {Promise<void>|null} _authenticatePromise - In-flight authentication promise shared by concurrent callers.
  * @property {() => Promise<FluentAuthManager>} init - Returns promise for authManager.
  * @property {(username?: string, password?: string) => Promise<void>} login - Logs in with the provided credentials.
  * @property {(refreshToken?: string) => Promise<string|null>} tryRefreshToken - Attempts to refresh the authentication token using the refresh token.
@@ -45,6 +47,7 @@ export function createAuthManager() {
         token: "",
         refreshToken: "",
         userInfo: {},
+        _authenticatePromise: null,
 
         /**
          * app token to use for authentication
@@ -117,10 +120,35 @@ export function createAuthManager() {
          * Authenticates the user with the JWT token or refreshes the token with
          * the refreshToken set before.
          *
+         * Single-flight: concurrent callers (e.g. parallel requests firing after
+         * the token expired) share one refresh instead of racing each other with
+         * the same refresh token — with token rotation only the first refresh
+         * would succeed and all others would end up with a 401.
+         *
          * @throws {Error} if JWT token and refreshToken are not set or both are invalid
          * @return {Promise<void>}
          */
         async authenticate() { // benutzt bei existierendem JWT oder RefreshToken, wenn keins vorhanden ERROR
+            if (this.token && isTokenValid(this.token)) {
+                return;
+            }
+
+            this._authenticatePromise ??= this._doAuthenticate()
+                .finally(() => { this._authenticatePromise = null; });
+
+            return this._authenticatePromise;
+        },
+
+        /**
+         * Performs the actual authentication/refresh. Never call directly —
+         * always go through authenticate(), which ensures only one refresh
+         * runs at a time.
+         *
+         * @private
+         * @throws {Error} if JWT token and refreshToken are not set or both are invalid
+         * @return {Promise<void>}
+         */
+        async _doAuthenticate() {
             console.log("authenticating:", this.token ? `token set, exp: ${jwtDecode(this.token).exp - (Date.now() / 1000)}` : "no token,", this.refreshToken, this.appToken);
 
             if (this.token && isTokenValid(this.token)) {

--- a/WebLibs/api/fluentRestClient.js
+++ b/WebLibs/api/fluentRestClient.js
@@ -15,6 +15,27 @@
  */
 
 /**
+ * Error thrown for non-ok HTTP responses. Carries the status code so callers
+ * can react to specific statuses (e.g. the automatic 401 retry in fluentApi)
+ * without parsing the message.
+ */
+export class RestError extends Error {
+    /**
+     * @param {string} method - HTTP method of the failed request.
+     * @param {string} url - Full URL of the failed request.
+     * @param {Response} res - The non-ok fetch response.
+     */
+    constructor(method, url, res) {
+        super(`${method} ${url} failed: ${res.status} ${res.statusText}`);
+        this.name = "RestError";
+        this.method = method;
+        this.url = url;
+        this.status = res.status;
+        this.statusText = res.statusText;
+    }
+}
+
+/**
  * Creates a REST client object with fluent API for making HTTP requests.
  * @returns {FluentRESTClient} The REST client object.
  */
@@ -71,7 +92,7 @@ export function restClient() {
                 return skipResponseParsing ? res : await this._parseReponse(res); 
             }
 
-            throw new Error(`GET ${finalUrl} failed: ${res.status} ${res.statusText}`);
+            throw new RestError("GET", finalUrl, res);
         },
 
         /**
@@ -91,7 +112,7 @@ export function restClient() {
                 return skipResponseParsing ? res : await this._parseReponse(res);
             }
 
-            throw new Error(`PUT ${finalUrl} failed: ${res.status} ${res.statusText}`);
+            throw new RestError("PUT", finalUrl, res);
         },
 
         /**
@@ -122,7 +143,7 @@ export function restClient() {
                 return skipResponseParsing ? res : await this._parseReponse(res);
             }
 
-            throw new Error(`POST ${finalUrl} failed: ${res.status} ${res.statusText}`);
+            throw new RestError("POST", finalUrl, res);
         },
 
         /**
@@ -145,7 +166,7 @@ export function restClient() {
                 return skipResponseParsing ? res : await this._parseReponse(res);
             }
 
-            throw new Error(`DELETE ${finalUrl} failed: ${res.status} ${res.statusText}`);
+            throw new RestError("DELETE", finalUrl, res);
         },
 
         _createHeaders(contentType) {

--- a/WebLibs/index.d.ts
+++ b/WebLibs/index.d.ts
@@ -7,6 +7,7 @@ export function createAuthManager(): FluentAuthManager;
 export function fluentIdasAuthManager(appToken: string, authBaseUrl: string): FluentAuthManager;
 export function fetchEnvConfig(envConfig?: string): Promise<EnvironmentConfig>;
 export function restClient(): FluentRESTClient;
+export class RestError extends Error { method: string; url: string; status: number; statusText: string; constructor(method: string, url: string, res: Response); }
 
 export type AblageApi = {
     get: (guid: string) => Promise<AblageDTO>;
@@ -1120,6 +1121,7 @@ export type FluentApi = {
     delete: (url?: string, payload?: object|FormData|Array<any>|string[]|string|null, auth?: boolean) => Promise<object|Array<any>>;
     createRestClient: () => FluentRESTClient;
     preCheck: (auth?: boolean) => Promise<void>;
+    _executeRequest: (auth: boolean, executeRequest: () => Promise<any>) => Promise<any>;
 };
 
 export type FluentAuthManager = {
@@ -1134,6 +1136,8 @@ export type FluentAuthManager = {
     useRefreshToken: (storedRefreshToken?: string|null) => FluentAuthManager;
     ensureAuthenticated: () => Promise<void>;
     authenticate: () => Promise<void>;
+    _doAuthenticate: () => Promise<void>;
+    _authenticatePromise: Promise<void>|null;
     init: () => Promise<FluentAuthManager>;
     login: (username?: string, password?: string) => Promise<void>;
     tryRefreshToken: (refreshToken?: string) => Promise<string|null>;

--- a/WebLibs/index.js
+++ b/WebLibs/index.js
@@ -2,7 +2,7 @@ export { createApi, fluentApi } from "./api/fluentApi";
 export { createIDASApi, idasFluentApi } from "./api/idasFluentApi";
 export { createAuthManager, fluentIdasAuthManager } from "./api/fluentAuthManager";
 export { fetchEnvConfig } from "./api/fluentEnvUtils";
-export { restClient } from "./api/fluentRestClient";
+export { restClient, RestError } from "./api/fluentRestClient";
 
 // Business Routines APIs
 export * from "./api/business/index.js";

--- a/WebLibs/scripts/generate-dts.mjs
+++ b/WebLibs/scripts/generate-dts.mjs
@@ -31,7 +31,8 @@ const rootFunctionDeclarationStatements = [
     "export function createAuthManager(): FluentAuthManager;",
     "export function fluentIdasAuthManager(appToken: string, authBaseUrl: string): FluentAuthManager;",
     "export function fetchEnvConfig(envConfig?: string): Promise<EnvironmentConfig>;",
-    "export function restClient(): FluentRESTClient;"
+    "export function restClient(): FluentRESTClient;",
+    "export class RestError extends Error { method: string; url: string; status: number; statusText: string; constructor(method: string, url: string, res: Response); }"
 ];
 
 const simpleImportTypePattern = /^import\((?:"|').+(?:"|')\)\.[A-Za-z0-9_$]+$/;


### PR DESCRIPTION
## Problem

Nach mehreren Stunden ohne Interaktion schlägt in NeherApp3-Modulen (z. B. m3) der erste Backend-Request mit **401 Unauthorized** fehl; danach funktioniert alles wieder. Zwei Ursachen in den WebLibs:

- `authenticate()` verschluckt fehlgeschlagene Refreshes (`tryRefreshToken` liefert bei `!res.ok` still `null`) — der Request geht anschließend mit dem **abgelaufenen Token** raus.
- Kein Single-Flight: parallele erste Requests feuern jeweils einen eigenen `LoginJwt/Refresh` mit demselben Refresh-Token (Race bei Token-Rotation, nur der erste gewinnt).

## Änderungen

- **fluentAuthManager:** `authenticate()` ist jetzt Single-Flight — parallele Aufrufer teilen sich über `_authenticatePromise` einen Refresh; die eigentliche Logik liegt unverändert in `_doAuthenticate()`.
- **fluentApi:** Alle Verben laufen durch `_executeRequest()` — bei 401 wird das Token verworfen, frisch authentifiziert und der Request **genau einmal** wiederholt. Andere Fehler und Clients ohne authManager verhalten sich exakt wie bisher.
- **fluentRestClient:** Non-ok-Antworten werfen die neue Klasse `RestError` (mit `status`, `method`, `url`, `statusText`); Fehlermeldungstext unverändert. Export über den Paket-Root, `index.d.ts` regeneriert.

## Verifikation

- ESLint auf den geänderten Dateien fehlerfrei.
- Verhalten mit gemocktem `fetch` getestet: 5 parallele Aufrufe → genau 1 Refresh; 401 → Refresh → Retry liefert Daten; 500 wird nicht wiederholt; dauerhaftes 401 → genau ein Retry (keine Schleife); ohne authManager kein Retry.

## Hinweis fürs Ausrollen

Der Single-Flight-Fix wirkt in Modulen erst, wenn der **NeherApp3-Host** die neue weblibs-Version einsetzt (die authManager-Instanz kommt vom Host). Der 401-Retry greift bereits, sobald ein Modul selbst die neue Version bündelt. Versions-Bump (→ 2.0.8) ist bewusst nicht Teil des PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)